### PR TITLE
feat(db): introduce department level abstractions to database

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -14,7 +14,7 @@ CREATE TABLE users(
     name VARCHAR(64) NOT NULL,
     email Email UNIQUE,
     picture VARCHAR(256) NOT NULL,
-    admin BOOLEAN NOT NULL,
+    admin BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (user_id)
 );
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -14,7 +14,22 @@ CREATE TABLE users(
     name VARCHAR(64) NOT NULL,
     email Email UNIQUE,
     picture VARCHAR(256) NOT NULL,
+    admin BOOLEAN NOT NULL,
     PRIMARY KEY (user_id)
+);
+
+CREATE TABLE depts(
+    dept_id SERIAL NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    PRIMARY KEY (dept_id)
+);
+
+CREATE TABLE dept_agents(
+    dept_agent_id SERIAL NOT NULL,
+    dept_id SERIAL NOT NULL REFERENCES depts (dept_id),
+    user_id GoogleUserId REFERENCES users (user_id),
+    head BOOLEAN NOT NULL,
+    PRIMARY KEY (dept_agent_id)
 );
 
 -- Pending OAuth logins. Must expire periodically.
@@ -33,12 +48,6 @@ CREATE TABLE sessions(
     PRIMARY KEY (session_id)
 );
 
-CREATE TABLE agents(
-    user_id UUID NOT NULL,
-    admin BOOLEAN NOT NULL,
-    PRIMARY KEY (user_id)
-);
-
 CREATE TABLE priorities(
     priority_id SERIAL NOT NULL,
     title VARCHAR(32) UNIQUE,
@@ -55,9 +64,9 @@ CREATE TABLE tickets(
     PRIMARY KEY (ticket_id)
 );
 
-CREATE TABLE assignment(
+CREATE TABLE assignments(
     ticket_id UUID NOT NULL REFERENCES tickets (ticket_id),
-    agent_id UUID NOT NULL REFERENCES agents (user_id),
+    agent_id SERIAL NOT NULL REFERENCES dept_agents (dept_agent_id),
     PRIMARY KEY (ticket_id, agent_id)
 );
 
@@ -77,8 +86,14 @@ CREATE TABLE labels(
     PRIMARY KEY (label_id)
 );
 
+CREATE TABLE dept_labels(
+    dept_id SERIAL NOT NULL REFERENCES depts (dept_id),
+    label_id SERIAL NOT NULL REFERENCES labels (label_id),
+    PRIMARY KEY (dept_id, label_id)
+);
+
 -- TODO: Let's consider a different name for the bridge table.
-CREATE TABLE ticket_to_label(
+CREATE TABLE ticket_labels(
     ticket_id UUID NOT NULL REFERENCES tickets (ticket_id),
     label_id SERIAL NOT NULL REFERENCES labels (label_id),
     PRIMARY KEY (ticket_id, label_id)

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -49,6 +49,8 @@ export async function createPending() {
 }
 
 export type TransactionScope<T> = (sql: Transaction) => T | Promise<T>;
+
+/** Starts a new transaction. */
 export function begin<T>(fn: TransactionScope<T>) {
     return sql.begin(sql => fn(new Transaction(sql)));
 }

--- a/src/lib/server/model/session.ts
+++ b/src/lib/server/model/session.ts
@@ -2,7 +2,7 @@ import { UserSchema } from './user';
 import { z } from 'zod';
 
 const CommonSchema = z.object({
-    session_id: z.string(),
+    session_id: z.string().uuid(),
     expiration: z.coerce.date(),
 });
 


### PR DESCRIPTION
This PR introduces department level abstractions in the database and made the necessary changes to other tables' schemas.

- Removed the `agents` table (deemed unnecessary as we can assign users to a department first, thereby distinguishing them as agents) and introduces `admin` field in `users` table (which was originally in the `agents` table schema).
- Created the `depts` table for the departments.
- Created the `dept_agents` table which indicates the agents assigned to each department with an additional field `head` that distinguishes a certain agent as a department head. (not to be confused with the `admin` or system admin as indicated in the `users` table.)
- Created the `dept_labels` table which indicates the labels that can be handled by each department as determined by the department head.
- Renamed `assignment` to `assignments`,  and `ticket_to_label` to `ticket_labels` to keep them consistent with the table naming scheme.
