### PR TITLE
feat(api): create new departments

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -128,3 +128,8 @@ $$ LANGUAGE SQL;
 CREATE FUNCTION create_label(title labels.title%TYPE, color labels.color%TYPE) RETURNS labels.label_id%TYPE AS $$
     INSERT INTO labels (title, color) VALUES (title, color) RETURNING label_id;
 $$ LANGUAGE SQL;
+
+-- DEPARTMENT FUNCTIONS
+CREATE FUNCTION create_dept(name depts.name%TYPE) RETURNS depts.dept_id%TYPE AS $$
+    INSERT INTO depts (name) VALUES (name) RETURNING dept_id;
+$$ LANGUAGE SQL;

--- a/src/api/dept.ts
+++ b/src/api/dept.ts
@@ -1,0 +1,24 @@
+import { BadInput, InsufficientPermissions, InvalidSession, UnexpectedStatusCode } from './error';
+import { type Dept, DeptSchema } from '$lib/model/dept';
+import { StatusCodes } from 'http-status-codes';
+
+/** Creates a new {@linkcode Dept} and returns the ID. */
+export async function create(name: Dept['name']) {
+    const res = await fetch('/api/dept', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ name }),
+    });
+    switch (res.status) {
+        case StatusCodes.CREATED:
+            return DeptSchema.shape.dept_id.parse(await res.json());
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(res.status);
+    }
+}

--- a/src/lib/model/dept.ts
+++ b/src/lib/model/dept.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const DeptSchema = z.object({
+    dept_id: z.number().int().positive(),
+    name: z.string().max(64),
+});
+
+export type Dept = z.infer<typeof DeptSchema>;

--- a/src/lib/server/database.test.ts
+++ b/src/lib/server/database.test.ts
@@ -41,6 +41,11 @@ it('should create a new label', async () => {
     expect(id).not.toStrictEqual(0);
 });
 
+it('should create a new department', async () => {
+    const id = await db.createDept('HATiD Support');
+    expect(id).not.toStrictEqual(0);
+});
+
 describe('invalid sessions', () => {
     it('should be null when fetching', async () => {
         const val = await db.getUserFromSession(randomUUID());

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -1,3 +1,4 @@
+import { type Dept, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
 import { type Pending, PendingSchema, type Session } from './model/session';
 import { type User, UserSchema } from '$lib/model/user';
@@ -89,4 +90,11 @@ export async function createLabel(title: Label['title'], color: Label['color']) 
     const [first, ...rest] = await sql`SELECT create_label(${title}, ${hex}) AS label_id`.execute();
     strictEqual(rest.length, 0);
     return LabelSchema.pick({ label_id: true }).parse(first);
+}
+
+/** Creates a new {@linkcode Dept} or department. Requires only the department name as input.  */
+export async function createDept(name: Dept['name']) {
+    const [first, ...rest] = await sql`SELECT create_dept(${name}) AS dept_id`.execute();
+    strictEqual(rest.length, 0);
+    return DeptSchema.pick({ dept_id: true }).parse(first);
 }

--- a/src/routes/api/dept/+server.ts
+++ b/src/routes/api/dept/+server.ts
@@ -1,0 +1,23 @@
+import { createDept, getUserFromSession } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const name = form.get('name');
+    if (name === null || name instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: session has expired so we must inform the client that they should log in again
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+
+    const id = await createDept(name);
+    return json(id, { status: StatusCodes.CREATED });
+};


### PR DESCRIPTION
This PR is basically based on and a simpler version of the previous PR (#3) applied for the creation of departments. In line with this, it introduces the API endpoint `POST /api/dept` which accepts a single parameter referring to the department's `name` and responds with a `dept_id` integer representing the ID number of the created department, if successful.

To make up for the simplicity, I will attempt to explain the flow of the implementation of this PR:
1. In `init.sql`, we create the `create_dept` function which performs the actual insertion of departments into the database and returns the department's ID number.
2.  We then create a `dept.ts` file in the `src/lib/model` folder to serve as validation of the department type `Dept` and its schema `DeptSchema`. The details of the department schema may be found in the LucidChart of the database.
3.  In `database.ts`, we import the `Dept` type and `DeptSchema` from the previous procedure and introduce a new `createDept` asynchronous function that invokes the `create_dept` function created in the first step with a parameter `name` or the department name. It also ensures that the received `dept_id` is singular and in the correct format.
4. In `database.test.ts`,  we create a new unit test for the creation of a department, ensuring that the received `dept_id` is not `0`.
5. In `src/routes/api/dept/+server.ts`, we create the new request handler/API endpoint for the creation of a department, obtaining the `name` value from the formData and returning the `dept_id` as well as a status code signaling the successful creation of the department.
6. Finally, in `src/api/dept.ts`, we create the client wrapper function for sending the aforementioned POST request to the endpoint, which requires the inclusion of a `name` parameter. The function also handles the possibility of different response status codes, in case the request is not successful.