### PR TITLE
feat(api): implement per-label deadlines

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -58,8 +58,8 @@ CREATE TABLE priorities(
 CREATE TABLE tickets(
     ticket_id UUID NOT NULL,
     title VARCHAR(128) NOT NULL,
-    open BOOLEAN NOT NULL,
-    deadline DATE,
+    open BOOLEAN NOT NULL DEFAULT TRUE,
+    due_date DATE NOT NULL DEFAULT 'infinity',
     priority_id SERIAL REFERENCES priorities (priority_id),
     PRIMARY KEY (ticket_id)
 );

--- a/db/init.sql
+++ b/db/init.sql
@@ -83,6 +83,7 @@ CREATE TABLE labels(
     label_id SERIAL NOT NULL,
     title VARCHAR(32) NOT NULL,
     color INT NOT NULL,
+    deadline INTERVAL DAY (0),
     PRIMARY KEY (label_id)
 );
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -83,7 +83,7 @@ CREATE TABLE labels(
     label_id SERIAL NOT NULL,
     title VARCHAR(32) NOT NULL,
     color INT NOT NULL,
-    deadline INTERVAL DAY (0),
+    deadline INTERVAL DAY,
     PRIMARY KEY (label_id)
 );
 
@@ -126,8 +126,8 @@ $$ LANGUAGE SQL;
 
 -- LABEL FUNCTIONS
 
-CREATE FUNCTION create_label(title labels.title%TYPE, color labels.color%TYPE) RETURNS labels.label_id%TYPE AS $$
-    INSERT INTO labels (title, color) VALUES (title, color) RETURNING label_id;
+CREATE FUNCTION create_label(title labels.title%TYPE, color labels.color%TYPE, deadline labels.deadline%TYPE) RETURNS labels.label_id%TYPE AS $$
+    INSERT INTO labels (title, color, deadline) VALUES (title, color, deadline) RETURNING label_id;
 $$ LANGUAGE SQL;
 
 -- DEPARTMENT FUNCTIONS

--- a/db/init.sql
+++ b/db/init.sql
@@ -93,7 +93,6 @@ CREATE TABLE dept_labels(
     PRIMARY KEY (dept_id, label_id)
 );
 
--- TODO: Let's consider a different name for the bridge table.
 CREATE TABLE ticket_labels(
     ticket_id UUID NOT NULL REFERENCES tickets (ticket_id),
     label_id SERIAL NOT NULL REFERENCES labels (label_id),

--- a/src/api/label.ts
+++ b/src/api/label.ts
@@ -3,11 +3,17 @@ import { type Label, LabelSchema } from '$lib/model/label';
 import { StatusCodes } from 'http-status-codes';
 
 /** Creates a new {@linkcode Label} and returns the ID. */
-export async function create(title: Label['title'], color: Label['color']) {
+export async function create(
+    title: Label['title'],
+    color: Label['color'],
+    deadline: Label['deadline'],
+) {
+    const body = new URLSearchParams({ title, color: color.toString(16) });
+    if (deadline !== null) body.set('deadline', deadline.toString(10));
     const res = await fetch('/api/label', {
         method: 'POST',
         credentials: 'same-origin',
-        body: new URLSearchParams({ title, color: color.toString(16) }),
+        body,
     });
     switch (res.status) {
         case StatusCodes.CREATED:
@@ -52,6 +58,31 @@ export async function editColor(lid: Label['label_id'], color: Label['color']) {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({ id: lid.toString(10), color: color.toString(16) }),
+    });
+    switch (res.status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.NOT_FOUND:
+            return false;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(res.status);
+    }
+}
+
+/** Edits the `deadline` field of a {@linkcode Label}. Returns `false` if not found. */
+export async function editDeadline(lid: Label['label_id'], deadline: Label['deadline']) {
+    const body = new URLSearchParams({ id: lid.toString(10) });
+    if (deadline !== null) body.set('deadline', deadline.toString(10));
+    const res = await fetch('/api/label/deadline', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        body,
     });
     switch (res.status) {
         case StatusCodes.NO_CONTENT:

--- a/src/lib/model/label.ts
+++ b/src/lib/model/label.ts
@@ -4,6 +4,7 @@ export const LabelSchema = z.object({
     label_id: z.number().int().positive(),
     title: z.string().max(32),
     color: z.number().int(),
+    deadline: z.number().int().positive().nullable(),
 });
 
 export type Label = z.infer<typeof LabelSchema>;

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -37,17 +37,24 @@ it('should create a new session', async () => {
 });
 
 it('should create and update labels', async () => {
-    const lid = await db.createLabel('Hello World', 0xc0debabe);
+    const lid = await db.createLabel('Hello World', 0xc0debabe, null);
     expect(lid).not.toStrictEqual(0);
+
+    const other = await db.createLabel('Hello World', 0xc0debabe, 10);
+    expect(other).not.toStrictEqual(0);
 
     expect(await db.editLabelTitle(lid, 'World Hello')).toStrictEqual(true);
     expect(await db.editLabelColor(lid, 0xdeadbeef)).toStrictEqual(true);
+    expect(await db.editLabelDeadline(lid, null)).toStrictEqual(true);
+    expect(await db.editLabelDeadline(lid, 5)).toStrictEqual(true);
 });
 
 it('should reject updating invalid labels', async () => {
     // NOTE: Postgres does not provide 0 as a valid `SERIAL`.
     expect(await db.editLabelTitle(0, 'World Hello')).toStrictEqual(false);
     expect(await db.editLabelColor(0, 0xdeadbeef)).toStrictEqual(false);
+    expect(await db.editLabelDeadline(0, null)).toStrictEqual(false);
+    expect(await db.editLabelDeadline(0, 5)).toStrictEqual(false);
 });
 
 it('should create a new department', async () => {

--- a/src/routes/api/label/deadline/+server.ts
+++ b/src/routes/api/label/deadline/+server.ts
@@ -1,19 +1,16 @@
-import { createLabel, getUserFromSession } from '$lib/server/database';
-import { error, json } from '@sveltejs/kit';
+import { editLabelDeadline, getUserFromSession } from '$lib/server/database';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
 
 // eslint-disable-next-line func-style
-export const POST: RequestHandler = async ({ cookies, request }) => {
+export const PATCH: RequestHandler = async ({ cookies, request }) => {
     // We choose form data here because it's more network-efficient than JSON.
     const form = await request.formData();
 
-    const title = form.get('title');
-    if (title === null || title instanceof File) throw error(StatusCodes.BAD_REQUEST);
-
-    const color = form.get('color');
-    if (color === null || color instanceof File) throw error(StatusCodes.BAD_REQUEST);
-    const hex = parseInt(color, 16);
+    const id = form.get('id');
+    if (id === null || id instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const lid = parseInt(id, 10);
 
     const deadline = form.get('deadline');
     if (deadline instanceof File) throw error(StatusCodes.BAD_REQUEST);
@@ -27,6 +24,7 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
     if (user === null) throw error(StatusCodes.UNAUTHORIZED);
     if (!user.admin) throw error(StatusCodes.FORBIDDEN);
 
-    const id = await createLabel(title, hex, days);
-    return json(id, { status: StatusCodes.CREATED });
+    const success = await editLabelDeadline(lid, days);
+    const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;
+    return new Response(null, { status });
 };


### PR DESCRIPTION
This adds a new nullable `deadline` property for the `labels` table, which basically stores the default deadline (as a number of days) for any ticket that has been created with a label. A `NULL` deadline simply means "no deadline" (i.e., unlimited number of days). For example, suppose a label with a default deadline of five days. Then, any ticket that is created with the label assigned to it must have a due date that is set five days from now.

As such, we must modify the original `POST /api/label` endpoint to account for the new `deadline` field. We also add a new endpoint `PATCH /api/label/deadline` for setting the `deadline` to some number of days or `null`.