### PR TITLE
feat(api): system administrator promotion/demotion

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -124,6 +124,11 @@ CREATE FUNCTION get_user_from_session(sid sessions.session_id%TYPE) RETURNS user
     SELECT users.* FROM sessions INNER JOIN users USING (user_id) WHERE session_id = sid;
 $$ LANGUAGE SQL;
 
+CREATE FUNCTION set_admin_for_user(uid users.user_id%TYPE, value users.admin%TYPE) RETURNS BOOLEAN AS $$
+    WITH _ AS (SELECT admin FROM users WHERE user_id = uid)
+        UPDATE users SET admin = value FROM _ WHERE user_id = uid RETURNING _.admin;
+$$ LANGUAGE SQL;
+
 -- LABEL FUNCTIONS
 
 CREATE FUNCTION create_label(title labels.title%TYPE, color labels.color%TYPE, deadline labels.deadline%TYPE) RETURNS labels.label_id%TYPE AS $$

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,33 @@
+import { BadInput, InsufficientPermissions, InvalidSession, UnexpectedStatusCode } from './error';
+import { StatusCodes } from 'http-status-codes';
+import type { User } from '$lib/model/user';
+
+/**
+ * Promotes/demotes a {@linkcode User} as a system administrator. Returns `true`
+ * if modified. Otherwise, `false` means that the database made no modifications
+ * because the intended new value is already its current value anyway. This probably
+ * means that the client is out-of-sync with the server. We should probably refresh.
+ */
+export async function setAdmin(id: User['user_id'], admin: User['admin']) {
+    const res = await fetch('/api/user/admin', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ id, admin: Number(admin).toString(10) }),
+    });
+    switch (res.status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.RESET_CONTENT:
+            return false;
+        case StatusCodes.NOT_FOUND:
+            return null;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(res.status);
+    }
+}

--- a/src/lib/model/user.ts
+++ b/src/lib/model/user.ts
@@ -7,7 +7,7 @@ export const UserSchema = z.object({
     name: z.string().max(64),
     email: z.string().max(40),
     picture: z.string().url(),
-    admin: z.boolean(),
+    admin: z.coerce.boolean(),
 });
 
 export type User = z.infer<typeof UserSchema>;

--- a/src/routes/api/user/admin/+server.ts
+++ b/src/routes/api/user/admin/+server.ts
@@ -1,0 +1,34 @@
+import { getUserFromSession, setAdminForUser } from '$lib/server/database';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
+
+// eslint-disable-next-line func-style
+export const PATCH: RequestHandler = async ({ cookies, request }) => {
+    // We choose form data here because it's more network-efficient than JSON.
+    const form = await request.formData();
+
+    const uid = form.get('id');
+    if (uid === null || uid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const rawAdmin = form.get('admin');
+    if (rawAdmin === null || rawAdmin instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const admin = Boolean(parseInt(rawAdmin, 10));
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: session has expired so we must inform the client that they should log in again
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+
+    const prev = await setAdminForUser(uid, admin);
+    if (prev === null) return new Response(null, { status: StatusCodes.NOT_FOUND });
+
+    // Return `205 Reset Content` if no change occurred because the caller must have expected
+    // to modify the administrator permissions. If we end up at the same place, then there
+    // must have been some data conflict between the client and the server. The page must be reset.
+    const status = prev === admin ? StatusCodes.RESET_CONTENT : StatusCodes.NO_CONTENT;
+    return new Response(null, { status });
+};


### PR DESCRIPTION
Requires #6 to be merged first.

This PR implements the endpoint `PATCH /api/user/admin`, which promotes/demotes a system administrator by their `user_id`.