### PR TITLE
feat(api): implement department renaming

### DIFF
--- a/src/lib/api/dept.ts
+++ b/src/lib/api/dept.ts
@@ -22,3 +22,26 @@ export async function create(name: Dept['name']) {
             throw new UnexpectedStatusCode(res.status);
     }
 }
+
+/** Edits the `name` field of a {@linkcode Dept}. Returns `false` if not found. */
+export async function editName(did: Dept['dept_id'], name: Dept['name']){
+    const res = await fetch('/api/dept/name', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ id: did.toString(10), name }),
+    });
+    switch (res.status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.NOT_FOUND:
+            return false;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(res.status);
+    } 
+}

--- a/src/lib/api/dept.ts
+++ b/src/lib/api/dept.ts
@@ -24,7 +24,7 @@ export async function create(name: Dept['name']) {
 }
 
 /** Edits the `name` field of a {@linkcode Dept}. Returns `false` if not found. */
-export async function editName(did: Dept['dept_id'], name: Dept['name']){
+export async function editName(did: Dept['dept_id'], name: Dept['name']) {
     const res = await fetch('/api/dept/name', {
         method: 'PATCH',
         credentials: 'same-origin',
@@ -43,5 +43,5 @@ export async function editName(did: Dept['dept_id'], name: Dept['name']){
             throw new InsufficientPermissions();
         default:
             throw new UnexpectedStatusCode(res.status);
-    } 
+    }
 }

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -67,9 +67,13 @@ it('should reject updating invalid labels', async () => {
     expect(await db.editLabelDeadline(0, 5)).toStrictEqual(false);
 });
 
-it('should create a new department', async () => {
-    const id = await db.createDept('HATiD Support');
-    expect(id).not.toStrictEqual(0);
+it('should create departments and update their names', async () => {
+    const did = await db.createDept('HATiD Support');
+    expect(did).not.toStrictEqual(0);
+
+    expect(await db.editDeptName(did, 'PUSO/BULSA Support')).toStrictEqual(true);
+    // NOTE: As above, 0 is not a valid value in Postgres
+    expect(await db.editDeptName(0, 'NotExistent Support')).toStrictEqual(false);
 });
 
 describe('invalid sessions', () => {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -112,13 +112,6 @@ export async function createLabel(
     return LabelSchema.pick({ label_id: true }).parse(first).label_id;
 }
 
-/** Creates a new {@linkcode Dept} or department. Requires only the department name as input.  */
-export async function createDept(name: Dept['name']) {
-    const [first, ...rest] = await sql`SELECT create_dept(${name}) AS dept_id`.execute();
-    strictEqual(rest.length, 0);
-    return DeptSchema.pick({ dept_id: true }).parse(first).dept_id;
-}
-
 /** Edits the `title` field of a {@linkcode Label}. Returns `false` if not found. */
 export async function editLabelTitle(lid: Label['label_id'], title: Label['title']) {
     const { count } =
@@ -161,3 +154,12 @@ export async function editLabelDeadline(lid: Label['label_id'], days: Label['dea
             throw new UnexpectedRowCount();
     }
 }
+
+/** Creates a new {@linkcode Dept} or department. Requires only the department name as input.  */
+export async function createDept(name: Dept['name']) {
+    const [first, ...rest] = await sql`SELECT create_dept(${name}) AS dept_id`.execute();
+    strictEqual(rest.length, 0);
+    return DeptSchema.pick({ dept_id: true }).parse(first).dept_id;
+}
+
+

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -163,3 +163,16 @@ export async function createDept(name: Dept['name']) {
 }
 
 
+/** Edits the `name` field of a {@linkcode Dept}. Returns `false` if not found. */
+export async function editDeptName(did: Dept['dept_id'], name: Dept['name']) {
+    const { count } =
+        await sql`UPDATE depts SET name = ${name} WHERE dept_id = ${did}`.execute();
+    switch (count) {
+        case 0:
+            return false;
+        case 1:
+            return true;
+        default:
+            throw new UnexpectedRowCount();
+    }
+}

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -162,11 +162,9 @@ export async function createDept(name: Dept['name']) {
     return DeptSchema.pick({ dept_id: true }).parse(first).dept_id;
 }
 
-
 /** Edits the `name` field of a {@linkcode Dept}. Returns `false` if not found. */
 export async function editDeptName(did: Dept['dept_id'], name: Dept['name']) {
-    const { count } =
-        await sql`UPDATE depts SET name = ${name} WHERE dept_id = ${did}`.execute();
+    const { count } = await sql`UPDATE depts SET name = ${name} WHERE dept_id = ${did}`.execute();
     switch (count) {
         case 0:
             return false;

--- a/src/routes/api/dept/name/+server.ts
+++ b/src/routes/api/dept/name/+server.ts
@@ -1,0 +1,28 @@
+import { editDeptName, getUserFromSession } from '$lib/server/database';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
+
+// eslint-disable-next-line func-style
+export const PATCH: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const id = form.get('id');
+    if (id === null || id instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const did = parseInt(id, 10);
+
+    const name = form.get('name');
+    if (name === null || name instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: session has expired so we must inform the client that they should log in again
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+
+    const success = await editDeptName(did, name);
+    const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;
+    return new Response(null, { status });
+};


### PR DESCRIPTION
This PR introduces the endpoint for editing the `name` of a `Dept` or department via `PATCH /api/dept/name`.