### PR TITLE
feat(db): implement more granular permission checks

### DIFF
--- a/src/lib/model/agent.ts
+++ b/src/lib/model/agent.ts
@@ -1,0 +1,11 @@
+import { DeptSchema } from './dept';
+import { UserSchema } from './user';
+import { z } from 'zod';
+
+export const AgentSchema = z.object({
+    dept_id: DeptSchema.shape.dept_id,
+    user_id: UserSchema.shape.user_id,
+    head: z.boolean(),
+});
+
+export type Agent = z.infer<typeof AgentSchema>;

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -29,9 +29,7 @@ it('should complete a full user journey', async () => {
             email: `${email}@example.com`,
             picture: 'http://example.com/avatar.png',
         });
-
-        const now = Date.now();
-        await sql.upgradePending(session_id, uid, new Date(now + 10000));
+        await sql.upgradePending(session_id, uid, new Date(Date.now() + 10000));
         return uid;
     });
 

--- a/src/routes/api/dept/+server.ts
+++ b/src/routes/api/dept/+server.ts
@@ -1,5 +1,6 @@
 import { createDept, isAdminSession } from '$lib/server/database';
 import { error, json } from '@sveltejs/kit';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 
@@ -22,6 +23,8 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     const id = await createDept(name);

--- a/src/routes/api/dept/name/+server.ts
+++ b/src/routes/api/dept/name/+server.ts
@@ -1,4 +1,5 @@
 import { editDeptName, isHeadSession } from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -26,6 +27,8 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     const success = await editDeptName(did, name);

--- a/src/routes/api/dept/name/+server.ts
+++ b/src/routes/api/dept/name/+server.ts
@@ -1,4 +1,4 @@
-import { editDeptName, getUserFromSession } from '$lib/server/database';
+import { editDeptName, isHeadSession } from '$lib/server/database';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -18,9 +18,15 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
     if (!sid) throw error(StatusCodes.UNAUTHORIZED);
 
     // TODO: session has expired so we must inform the client that they should log in again
-    const user = await getUserFromSession(sid);
-    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
-    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+    const head = await isHeadSession(sid, did);
+    switch (head) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+    }
 
     const success = await editDeptName(did, name);
     const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;

--- a/src/routes/api/label/+server.ts
+++ b/src/routes/api/label/+server.ts
@@ -1,4 +1,4 @@
-import { createLabel, getUserFromSession } from '$lib/server/database';
+import { createLabel, isAdminSession } from '$lib/server/database';
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
@@ -23,9 +23,15 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
     if (!sid) throw error(StatusCodes.UNAUTHORIZED);
 
     // TODO: session has expired so we must inform the client that they should log in again
-    const user = await getUserFromSession(sid);
-    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
-    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+    const admin = await isAdminSession(sid);
+    switch (admin) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+    }
 
     const id = await createLabel(title, hex, days);
     return json(id, { status: StatusCodes.CREATED });

--- a/src/routes/api/label/+server.ts
+++ b/src/routes/api/label/+server.ts
@@ -1,5 +1,6 @@
 import { createLabel, isAdminSession } from '$lib/server/database';
 import { error, json } from '@sveltejs/kit';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 
@@ -31,6 +32,8 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     const id = await createLabel(title, hex, days);

--- a/src/routes/api/label/color/+server.ts
+++ b/src/routes/api/label/color/+server.ts
@@ -1,4 +1,5 @@
 import { editLabelColor, isAdminSession } from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -28,6 +29,8 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     const success = await editLabelColor(lid, hex);

--- a/src/routes/api/label/color/+server.ts
+++ b/src/routes/api/label/color/+server.ts
@@ -1,4 +1,4 @@
-import { editLabelColor, getUserFromSession } from '$lib/server/database';
+import { editLabelColor, isAdminSession } from '$lib/server/database';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -20,9 +20,15 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
     if (!sid) throw error(StatusCodes.UNAUTHORIZED);
 
     // TODO: session has expired so we must inform the client that they should log in again
-    const user = await getUserFromSession(sid);
-    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
-    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+    const admin = await isAdminSession(sid);
+    switch (admin) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+    }
 
     const success = await editLabelColor(lid, hex);
     const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;

--- a/src/routes/api/label/deadline/+server.ts
+++ b/src/routes/api/label/deadline/+server.ts
@@ -1,4 +1,5 @@
 import { editLabelDeadline, isAdminSession } from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -28,6 +29,8 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     const success = await editLabelDeadline(lid, days);

--- a/src/routes/api/label/deadline/+server.ts
+++ b/src/routes/api/label/deadline/+server.ts
@@ -1,4 +1,4 @@
-import { editLabelDeadline, getUserFromSession } from '$lib/server/database';
+import { editLabelDeadline, isAdminSession } from '$lib/server/database';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -20,9 +20,15 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
     if (!sid) throw error(StatusCodes.UNAUTHORIZED);
 
     // TODO: session has expired so we must inform the client that they should log in again
-    const user = await getUserFromSession(sid);
-    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
-    if (!user.admin) throw error(StatusCodes.FORBIDDEN);
+    const admin = await isAdminSession(sid);
+    switch (admin) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+    }
 
     const success = await editLabelDeadline(lid, days);
     const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;

--- a/src/routes/api/label/title/+server.ts
+++ b/src/routes/api/label/title/+server.ts
@@ -1,4 +1,5 @@
 import { editLabelTitle, isAdminSession } from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -27,6 +28,8 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     const success = await editLabelTitle(lid, title);

--- a/src/routes/api/user/admin/+server.ts
+++ b/src/routes/api/user/admin/+server.ts
@@ -1,4 +1,5 @@
 import { isAdminSession, setAdminForUser } from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -27,6 +28,8 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
             throw error(StatusCodes.FORBIDDEN);
         case true:
             break;
+        default:
+            throw new AssertionError();
     }
 
     // FIXME: disallow self-downgrade of permission


### PR DESCRIPTION
This PR implements department-level and system-level permission checks. This required me to remove the `dept_agents.dept_agent_id` field in favor of the composite primary key `(dept_id, user_id)`. In line with the more granular checks, I have also refactored the endpoints to use the new helper functions.