### PR TITLE
feat(api): implement priority creation

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -50,7 +50,7 @@ CREATE TABLE sessions(
 CREATE TABLE priorities(
     priority_id SERIAL NOT NULL,
     title VARCHAR(32) UNIQUE,
-    priority INT NOT NULL UNIQUE,
+    priority INT NOT NULL,
     PRIMARY KEY (priority_id)
 );
 
@@ -138,6 +138,12 @@ $$ LANGUAGE SQL;
 
 CREATE FUNCTION create_label(title labels.title%TYPE, color labels.color%TYPE, deadline labels.deadline%TYPE) RETURNS labels.label_id%TYPE AS $$
     INSERT INTO labels (title, color, deadline) VALUES (title, color, deadline) RETURNING label_id;
+$$ LANGUAGE SQL;
+
+-- PRIORITY FUNCTIONS
+
+CREATE FUNCTION create_priority(title priorities.title%TYPE, priority priorities.priority%TYPE) RETURNS priorities.priority_id%TYPE AS $$
+    INSERT INTO priorities (title, priority) VALUES (title, priority) RETURNING priority_id;
 $$ LANGUAGE SQL;
 
 -- DEPARTMENT FUNCTIONS

--- a/db/init.sql
+++ b/db/init.sql
@@ -55,7 +55,7 @@ CREATE TABLE priorities(
 );
 
 CREATE TABLE tickets(
-    ticket_id UUID NOT NULL,
+    ticket_id UUID NOT NULL DEFAULT gen_random_uuid(),
     title VARCHAR(128) NOT NULL,
     open BOOLEAN NOT NULL DEFAULT TRUE,
     due_date DATE NOT NULL DEFAULT 'infinity',
@@ -72,12 +72,12 @@ CREATE TABLE assignments(
 );
 
 CREATE TABLE messages(
-    message_id UUID NOT NULL,
     ticket_id UUID NOT NULL REFERENCES tickets (ticket_id),
-    creation TIMESTAMPTZ NOT NULL,
+    message_id SERIAL NOT NULL,
+    creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     content VARCHAR(1024) NOT NULL,
     author_id GoogleUserId REFERENCES users (user_id),
-    PRIMARY KEY (message_id)
+    PRIMARY KEY (ticket_id, message_id)
 );
 
 CREATE TABLE labels(

--- a/src/lib/api/dept.ts
+++ b/src/lib/api/dept.ts
@@ -25,12 +25,12 @@ export async function create(name: Dept['name']) {
 
 /** Edits the `name` field of a {@linkcode Dept}. Returns `false` if not found. */
 export async function editName(did: Dept['dept_id'], name: Dept['name']) {
-    const res = await fetch('/api/dept/name', {
+    const { status } = await fetch('/api/dept/name', {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({ id: did.toString(10), name }),
     });
-    switch (res.status) {
+    switch (status) {
         case StatusCodes.NO_CONTENT:
             return true;
         case StatusCodes.NOT_FOUND:
@@ -42,6 +42,6 @@ export async function editName(did: Dept['dept_id'], name: Dept['name']) {
         case StatusCodes.FORBIDDEN:
             throw new InsufficientPermissions();
         default:
-            throw new UnexpectedStatusCode(res.status);
+            throw new UnexpectedStatusCode(status);
     }
 }

--- a/src/lib/api/label.ts
+++ b/src/lib/api/label.ts
@@ -31,12 +31,12 @@ export async function create(
 
 /** Edits the `title` field of a {@linkcode Label}. Returns `false` if not found. */
 export async function editTitle(lid: Label['label_id'], title: Label['title']) {
-    const res = await fetch('/api/label/title', {
+    const { status } = await fetch('/api/label/title', {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({ id: lid.toString(10), title }),
     });
-    switch (res.status) {
+    switch (status) {
         case StatusCodes.NO_CONTENT:
             return true;
         case StatusCodes.NOT_FOUND:
@@ -48,18 +48,18 @@ export async function editTitle(lid: Label['label_id'], title: Label['title']) {
         case StatusCodes.FORBIDDEN:
             throw new InsufficientPermissions();
         default:
-            throw new UnexpectedStatusCode(res.status);
+            throw new UnexpectedStatusCode(status);
     }
 }
 
 /** Edits the `color` field of a {@linkcode Label}. Returns `false` if not found. */
 export async function editColor(lid: Label['label_id'], color: Label['color']) {
-    const res = await fetch('/api/label/color', {
+    const { status } = await fetch('/api/label/color', {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({ id: lid.toString(10), color: color.toString(16) }),
     });
-    switch (res.status) {
+    switch (status) {
         case StatusCodes.NO_CONTENT:
             return true;
         case StatusCodes.NOT_FOUND:
@@ -71,7 +71,7 @@ export async function editColor(lid: Label['label_id'], color: Label['color']) {
         case StatusCodes.FORBIDDEN:
             throw new InsufficientPermissions();
         default:
-            throw new UnexpectedStatusCode(res.status);
+            throw new UnexpectedStatusCode(status);
     }
 }
 
@@ -79,12 +79,12 @@ export async function editColor(lid: Label['label_id'], color: Label['color']) {
 export async function editDeadline(lid: Label['label_id'], deadline: Label['deadline']) {
     const body = new URLSearchParams({ id: lid.toString(10) });
     if (deadline !== null) body.set('deadline', deadline.toString(10));
-    const res = await fetch('/api/label/deadline', {
+    const { status } = await fetch('/api/label/deadline', {
         method: 'PATCH',
         credentials: 'same-origin',
         body,
     });
-    switch (res.status) {
+    switch (status) {
         case StatusCodes.NO_CONTENT:
             return true;
         case StatusCodes.NOT_FOUND:
@@ -96,6 +96,6 @@ export async function editDeadline(lid: Label['label_id'], deadline: Label['dead
         case StatusCodes.FORBIDDEN:
             throw new InsufficientPermissions();
         default:
-            throw new UnexpectedStatusCode(res.status);
+            throw new UnexpectedStatusCode(status);
     }
 }

--- a/src/lib/api/priority.ts
+++ b/src/lib/api/priority.ts
@@ -1,0 +1,25 @@
+import { BadInput, InsufficientPermissions, InvalidSession, UnexpectedStatusCode } from './error';
+import { type Priority, PrioritySchema } from '$lib/model/priority';
+import { StatusCodes } from 'http-status-codes';
+
+/** Creates a new {@linkcode Label} and returns the ID. */
+export async function create(title: Priority['title'], priority: Priority['priority']) {
+    const body = new URLSearchParams({ title, priority: priority.toString(10) });
+    const res = await fetch('/api/priority', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body,
+    });
+    switch (res.status) {
+        case StatusCodes.CREATED:
+            return PrioritySchema.shape.priority_id.parse(await res.json());
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(res.status);
+    }
+}

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -9,12 +9,12 @@ import type { User } from '$lib/model/user';
  * means that the client is out-of-sync with the server. We should probably refresh.
  */
 export async function setAdmin(id: User['user_id'], admin: User['admin']) {
-    const res = await fetch('/api/user/admin', {
+    const { status } = await fetch('/api/user/admin', {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({ id, admin: Number(admin).toString(10) }),
     });
-    switch (res.status) {
+    switch (status) {
         case StatusCodes.NO_CONTENT:
             return true;
         case StatusCodes.RESET_CONTENT:
@@ -28,6 +28,6 @@ export async function setAdmin(id: User['user_id'], admin: User['admin']) {
         case StatusCodes.FORBIDDEN:
             throw new InsufficientPermissions();
         default:
-            throw new UnexpectedStatusCode(res.status);
+            throw new UnexpectedStatusCode(status);
     }
 }

--- a/src/lib/model/priority.ts
+++ b/src/lib/model/priority.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const PrioritySchema = z.object({
+    priority_id: z.number().int().positive(),
+    title: z.string().max(32),
+    priority: z.number().int(),
+});
+
+export type Priority = z.infer<typeof PrioritySchema>;

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -70,6 +70,14 @@ it('should create and update labels', async () => {
     expect(await db.editLabelDeadline(lid, 5)).toStrictEqual(true);
 });
 
+it('should create and update priorities', async () => {
+    const bytes = getRandomValues(new Uint8Array(21));
+    const priority = Buffer.from(bytes).toString('base64');
+    const pid = await db.createPriority(priority, 0);
+    expect(pid).not.toStrictEqual(0);
+    // TODO: update priority properties here
+});
+
 describe.concurrent('invalid labels', () => {
     // NOTE: Postgres does not provide 0 as a valid `SERIAL`.
     it('should reject title update', async ({ expect }) => {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -2,6 +2,7 @@ import { type Agent, AgentSchema } from '$lib/model/agent';
 import { type Dept, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
 import { type Pending, PendingSchema, type Session } from '$lib/server/model/session';
+import { type Priority, PrioritySchema } from '$lib/model/priority';
 import { type User, UserSchema } from '$lib/model/user';
 import { default as assert, strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
@@ -172,6 +173,14 @@ export async function editLabelDeadline(lid: Label['label_id'], days: Label['dea
         default:
             throw new UnexpectedRowCount();
     }
+}
+
+/** Creates a new {@linkcode Priority} or department. Requires only the department name as input.  */
+export async function createPriority(title: Priority['title'], priority: Priority['priority']) {
+    const [first, ...rest] =
+        await sql`SELECT create_priority(${title}, ${priority}) AS priority_id`.execute();
+    strictEqual(rest.length, 0);
+    return PrioritySchema.pick({ priority_id: true }).parse(first).priority_id;
 }
 
 /** Creates a new {@linkcode Dept} or department. Requires only the department name as input.  */

--- a/src/routes/api/priority/+server.ts
+++ b/src/routes/api/priority/+server.ts
@@ -1,0 +1,37 @@
+import { createPriority, isAdminSession } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    // We choose form data here because it's more network-efficient than JSON.
+    const form = await request.formData();
+
+    const title = form.get('title');
+    if (title === null || title instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const prio = form.get('priority');
+    if (prio === null || prio instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const priority = parseInt(prio, 10);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: session has expired so we must inform the client that they should log in again
+    const admin = await isAdminSession(sid);
+    switch (admin) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+        default:
+            throw new AssertionError();
+    }
+
+    const id = await createPriority(title, priority);
+    return json(id, { status: StatusCodes.CREATED });
+};


### PR DESCRIPTION
Requires #10 to be merged.

This PR implements the `POST /api/priority` endpoint, which creates a single entry in the `priorities` table. In the future, this allows user to assign a priority to a ticket with an associated "title" and "priority level". In the far future, this lets us sort an inbox by priority.