### PR TITLE
feat(api): implement ticket creation

### DIFF
--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -1,0 +1,36 @@
+import { BadInput, InvalidSession, UnexpectedStatusCode } from './error';
+import { type Message, type Ticket, TicketSchema } from '$lib/model/ticket';
+import type { Label } from '$lib/model/label';
+import { StatusCodes } from 'http-status-codes';
+
+export async function create(
+    title: Ticket['title'],
+    content: Message['body'],
+    labels: Label['label_id'][],
+) {
+    const body = new URLSearchParams({ title, body: content });
+    for (const label of labels) {
+        const int = label >> 0;
+        const data = int.toString(10);
+        body.append('label', data);
+    }
+
+    const res = await fetch('/api/ticket', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body,
+    });
+
+    switch (res.status) {
+        case StatusCodes.CREATED:
+            return TicketSchema.shape.ticket_id.parse(await res.text());
+        case StatusCodes.NOT_FOUND:
+            return null;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        default:
+            throw new UnexpectedStatusCode(res.status);
+    }
+}

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -3,6 +3,7 @@ import { type Message, type Ticket, TicketSchema } from '$lib/model/ticket';
 import type { Label } from '$lib/model/label';
 import { StatusCodes } from 'http-status-codes';
 
+/** Creates a new {@linkcode Ticket} and returns its `ticket_id` if successful. */
 export async function create(
     title: Ticket['title'],
     content: Message['body'],

--- a/src/lib/model/ticket.ts
+++ b/src/lib/model/ticket.ts
@@ -1,0 +1,29 @@
+import { LabelSchema } from '$lib/model/label';
+import { PrioritySchema } from '$lib/model/priority';
+import { UserSchema } from '$lib/model/user';
+import { z } from 'zod';
+
+export const TicketSchema = z.object({
+    ticket_id: z.string().uuid(),
+    title: z.string().max(128),
+    open: z.boolean(),
+    due_date: z.coerce.date(),
+    priority_id: PrioritySchema.shape.priority_id,
+});
+
+export const TicketLabelSchema = z.object({
+    ticket_id: TicketSchema.shape.ticket_id,
+    label_id: LabelSchema.shape.label_id,
+});
+
+export const Message = z.object({
+    author_id: UserSchema.shape.user_id,
+    ticket_id: TicketSchema.shape.ticket_id,
+    message_id: z.number().int().positive(),
+    creation: z.coerce.date(),
+    body: z.string().max(1024),
+});
+
+export type Ticket = z.infer<typeof TicketSchema>;
+export type TicketLabel = z.infer<typeof TicketLabelSchema>;
+export type Message = z.infer<typeof Message>;

--- a/src/lib/server/database/error.ts
+++ b/src/lib/server/database/error.ts
@@ -3,3 +3,29 @@ export class UnexpectedRowCount extends Error {
         super('unexpected row count');
     }
 }
+
+export class UnexpectedTableName extends Error {
+    #table: string;
+
+    constructor(table: string) {
+        super(`unexpected table ${table}`);
+        this.#table = table;
+    }
+
+    get table() {
+        return this.#table;
+    }
+}
+
+export class UnexpectedConstraintName extends Error {
+    #constraint: string;
+
+    constructor(constraint: string) {
+        super(`unexpected constraint ${constraint}`);
+        this.#constraint = constraint;
+    }
+
+    get constraint() {
+        return this.#constraint;
+    }
+}

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -303,6 +303,7 @@ export const enum CreateTicketResult {
     NoLabels,
 }
 
+/** Creates a new {@linkcode Ticket} and returns its `ticket_id` if successful. */
 export async function createTicket(
     title: Ticket['title'],
     author: Message['author_id'],

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1,12 +1,13 @@
 import { type Agent, AgentSchema } from '$lib/model/agent';
-import { AssertionError, default as assert, strictEqual } from 'node:assert/strict';
 import { type Dept, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
+import { type Message, type Ticket, type TicketLabel, TicketSchema } from '$lib/model/ticket';
 import { type Pending, PendingSchema, type Session } from '$lib/server/model/session';
 import { type Priority, PrioritySchema } from '$lib/model/priority';
+import { UnexpectedConstraintName, UnexpectedRowCount, UnexpectedTableName } from './error';
 import { type User, UserSchema } from '$lib/model/user';
+import { default as assert, strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
-import { UnexpectedRowCount } from './error';
 import env from '$lib/server/env/postgres';
 
 export { UnexpectedRowCount };
@@ -112,7 +113,7 @@ export async function setAdminForUser(uid: User['user_id'], admin: User['admin']
 export async function createLabel(
     title: Label['title'],
     color: Label['color'],
-    days: Label['deadline'],
+    days: Label['deadline'] = null,
 ) {
     // Recall that the `number` type in JavaScript is actually an IEEE-754-2019 double-precision
     // floating-point number. See [Section 6.1.6.1][ieee-754] for more details. However, note that
@@ -262,15 +263,23 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
     } catch (err) {
         const isExpected = err instanceof pg.PostgresError;
         if (!isExpected) throw err;
-        strictEqual(err.code, '23503');
-        strictEqual(err.table_name, 'dept_agents');
-        switch (err.constraint_name) {
+
+        const { code, table_name, constraint_name } = err;
+        strictEqual(code, '23503');
+
+        if (table_name !== 'dept_agents') {
+            assert(table_name);
+            throw new UnexpectedTableName(table_name);
+        }
+
+        switch (constraint_name) {
             case 'dept_agents_dept_id_fkey':
                 return AddDeptAgentResult.NoDept;
             case 'dept_agents_user_id_fkey':
                 return AddDeptAgentResult.NoUser;
             default:
-                throw new AssertionError();
+                assert(constraint_name);
+                throw new UnexpectedConstraintName(constraint_name);
         }
     }
 }
@@ -285,4 +294,48 @@ export async function setHeadForAgent(
         await sql`SELECT * FROM set_head_for_agent(${did}, ${uid}, ${head}) AS head WHERE head IS NOT NULL`.execute();
     strictEqual(rest.length, 0);
     return typeof first === 'undefined' ? null : AgentSchema.pick({ head: true }).parse(first).head;
+}
+
+export const enum CreateTicketResult {
+    /** Author not found. */
+    NoAuthor,
+    /** One of the provided labels did not exist. */
+    NoLabels,
+}
+
+export async function createTicket(
+    title: Ticket['title'],
+    author: Message['author_id'],
+    body: Message['body'],
+    labels: TicketLabel['label_id'][],
+) {
+    try {
+        const [first, ...rest] =
+            await sql`SELECT create_ticket(${title}, ${author}, ${body}, ${labels}) AS ticket_id`;
+        strictEqual(rest.length, 0);
+        return TicketSchema.pick({ ticket_id: true }).parse(first).ticket_id;
+    } catch (err) {
+        const isExpected = err instanceof pg.PostgresError;
+        if (!isExpected) throw err;
+
+        const { code, table_name, constraint_name } = err;
+        strictEqual(code, '23503');
+
+        switch (table_name) {
+            case 'ticket_labels':
+                if (constraint_name === 'ticket_labels_label_id_fkey')
+                    return CreateTicketResult.NoLabels;
+                break;
+            case 'messages':
+                if (constraint_name === 'messages_author_id_fkey')
+                    return CreateTicketResult.NoAuthor;
+                break;
+            default:
+                assert(table_name);
+                throw new UnexpectedTableName(table_name);
+        }
+
+        assert(constraint_name);
+        throw new UnexpectedConstraintName(constraint_name);
+    }
 }

--- a/src/routes/api/ticket/+server.ts
+++ b/src/routes/api/ticket/+server.ts
@@ -1,8 +1,8 @@
 import { CreateTicketResult, createTicket, getUserFromSession } from '$lib/server/database';
-import { error } from '@sveltejs/kit';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
 
 // eslint-disable-next-line func-style
 export const POST: RequestHandler = async ({ cookies, request }) => {

--- a/src/routes/api/ticket/+server.ts
+++ b/src/routes/api/ticket/+server.ts
@@ -1,0 +1,38 @@
+import { CreateTicketResult, createTicket, getUserFromSession } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const title = form.get('title');
+    if (title === null || title instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const body = form.get('body');
+    if (body === null || body instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const labels = form.getAll('label').map(entry => {
+        if (entry === null || entry instanceof File) throw error(StatusCodes.BAD_REQUEST);
+        return parseInt(entry, 10) >> 0;
+    });
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+
+    const result = await createTicket(title, user.user_id, body, labels);
+    if (typeof result === 'string') return json(result, { status: StatusCodes.CREATED });
+
+    switch (result) {
+        case CreateTicketResult.NoAuthor:
+        case CreateTicketResult.NoLabels:
+            throw error(StatusCodes.NOT_FOUND);
+        default:
+            throw new AssertionError();
+    }
+};

--- a/src/routes/api/ticket/+server.ts
+++ b/src/routes/api/ticket/+server.ts
@@ -1,5 +1,5 @@
 import { CreateTicketResult, createTicket, getUserFromSession } from '$lib/server/database';
-import { error, json } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
@@ -26,7 +26,7 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
     if (user === null) throw error(StatusCodes.UNAUTHORIZED);
 
     const result = await createTicket(title, user.user_id, body, labels);
-    if (typeof result === 'string') return json(result, { status: StatusCodes.CREATED });
+    if (typeof result === 'string') return new Response(result, { status: StatusCodes.CREATED });
 
     switch (result) {
         case CreateTicketResult.NoAuthor:


### PR DESCRIPTION
This PR implements the ticket creation API: `POST /api/ticket`. It accepts the following arguments as a `application/x-www-urlencoded` request body:

* The `title` of the ticket.
* The `content` of the first message in the thread.
* Zero or more `label` IDs which automatically triage the ticket.