### PR TITLE
feat(api): opting in to department-specific label subscriptions

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -240,6 +240,15 @@ TYPE AS $$
         UPDATE dept_agents SET head = value FROM _ WHERE dept_id = did AND user_id = uid RETURNING _.head;
 $$ LANGUAGE SQL;
 
+CREATE FUNCTION subscribe_dept_to_label (
+    did dept_labels.dept_id %
+    TYPE,
+    lid dept_labels.label_id %
+    TYPE
+) RETURNS VOID AS $$
+    INSERT INTO dept_labels (dept_id, label_id) VALUES (did, lid);
+$$ LANGUAGE SQL;
+
 -- TICKET FUNCTIONS
 CREATE FUNCTION create_ticket (
     title tickets.title %

--- a/src/lib/api/dept.ts
+++ b/src/lib/api/dept.ts
@@ -1,5 +1,5 @@
 import { BadInput, InsufficientPermissions, InvalidSession, UnexpectedStatusCode } from './error';
-import { type Dept, DeptSchema } from '$lib/model/dept';
+import { type Dept, type DeptLabel, DeptSchema } from '$lib/model/dept';
 import { StatusCodes } from 'http-status-codes';
 
 /** Creates a new {@linkcode Dept} and returns the ID. */
@@ -35,6 +35,35 @@ export async function editName(did: Dept['dept_id'], name: Dept['name']) {
             return true;
         case StatusCodes.NOT_FOUND:
             return false;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
+    }
+}
+
+/**
+ * Subscribes a {@linkcode Dept} to a {@linkcode Label}. If any of `did` and `lid` do not exist,
+ * this function returns `null`. Returns `true` if successfully created and `false` otherwise if
+ * the `did`-`lid` pair already exists in the database (in which case nothing is done).
+ */
+export async function subscribeToLabel(did: DeptLabel['dept_id'], lid: DeptLabel['label_id']) {
+    const { status } = await fetch('/api/dept/label', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ dept: did.toString(10), label: lid.toString(10) }),
+    });
+    switch (status) {
+        case StatusCodes.CREATED:
+            return true;
+        case StatusCodes.CONFLICT:
+            return false;
+        case StatusCodes.NOT_FOUND:
+            return null;
         case StatusCodes.BAD_REQUEST:
             throw new BadInput();
         case StatusCodes.UNAUTHORIZED:

--- a/src/lib/model/dept.ts
+++ b/src/lib/model/dept.ts
@@ -1,3 +1,4 @@
+import { LabelSchema } from './label';
 import { z } from 'zod';
 
 export const DeptSchema = z.object({
@@ -5,4 +6,10 @@ export const DeptSchema = z.object({
     name: z.string().max(64),
 });
 
+export const DeptLabelSchema = z.object({
+    dept_id: DeptSchema.shape.dept_id,
+    label_id: LabelSchema.shape.label_id,
+});
+
 export type Dept = z.infer<typeof DeptSchema>;
+export type DeptLabel = z.infer<typeof DeptLabelSchema>;

--- a/src/lib/server/database/error.ts
+++ b/src/lib/server/database/error.ts
@@ -36,3 +36,16 @@ export class UnexpectedConstraintName extends Error {
         return this.#constraint;
     }
 }
+
+export class UnexpectedErrorCode extends Error {
+    #code: string;
+
+    constructor(code: string) {
+        super(`unexpected error code ${code}`);
+        this.#code = code;
+    }
+
+    get code() {
+        return this.#code;
+    }
+}

--- a/src/lib/server/database/error.ts
+++ b/src/lib/server/database/error.ts
@@ -1,6 +1,13 @@
 export class UnexpectedRowCount extends Error {
-    constructor() {
-        super('unexpected row count');
+    #count: number;
+
+    constructor(count: number) {
+        super(`unexpected row count ${count}`);
+        this.#count = count;
+    }
+
+    get count() {
+        return this.#count;
     }
 }
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -97,6 +97,12 @@ it('should complete a full user journey', async () => {
     // Valid user with labels
     const tid = await db.createTicket('With Label', uid, 'yay!', [coolLabel]);
     expect(typeof tid).toStrictEqual('string');
+
+    expect(await db.subscribeDeptToLabel(0, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
+    expect(await db.subscribeDeptToLabel(0, coolLabel)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
+    expect(await db.subscribeDeptToLabel(did, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoLabel);
+    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(db.SubscribeDeptToLabelResult.Success);
+    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(db.SubscribeDeptToLabelResult.Exists);
 });
 
 it('should reject promoting non-existent users', async () => {

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -99,18 +99,26 @@ it('should complete a full user journey', async () => {
     expect(typeof tid).toStrictEqual('string');
 
     expect(await db.subscribeDeptToLabel(0, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
-    expect(await db.subscribeDeptToLabel(0, coolLabel)).toStrictEqual(
-        db.SubscribeDeptToLabelResult.NoDept,
-    );
-    expect(await db.subscribeDeptToLabel(did, 0)).toStrictEqual(
-        db.SubscribeDeptToLabelResult.NoLabel,
-    );
-    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(
-        db.SubscribeDeptToLabelResult.Success,
-    );
-    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(
-        db.SubscribeDeptToLabelResult.Exists,
-    );
+
+    {
+        const result = await db.subscribeDeptToLabel(0, coolLabel);
+        expect(result).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
+    }
+
+    {
+        const result = await db.subscribeDeptToLabel(did, 0);
+        expect(result).toStrictEqual(db.SubscribeDeptToLabelResult.NoLabel);
+    }
+
+    {
+        const result = await db.subscribeDeptToLabel(did, coolLabel);
+        expect(result).toStrictEqual(db.SubscribeDeptToLabelResult.Success);
+    }
+
+    {
+        const result = await db.subscribeDeptToLabel(did, coolLabel);
+        expect(result).toStrictEqual(db.SubscribeDeptToLabelResult.Exists);
+    }
 });
 
 it('should reject promoting non-existent users', async () => {

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -99,10 +99,18 @@ it('should complete a full user journey', async () => {
     expect(typeof tid).toStrictEqual('string');
 
     expect(await db.subscribeDeptToLabel(0, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
-    expect(await db.subscribeDeptToLabel(0, coolLabel)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
-    expect(await db.subscribeDeptToLabel(did, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoLabel);
-    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(db.SubscribeDeptToLabelResult.Success);
-    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(db.SubscribeDeptToLabelResult.Exists);
+    expect(await db.subscribeDeptToLabel(0, coolLabel)).toStrictEqual(
+        db.SubscribeDeptToLabelResult.NoDept,
+    );
+    expect(await db.subscribeDeptToLabel(did, 0)).toStrictEqual(
+        db.SubscribeDeptToLabelResult.NoLabel,
+    );
+    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(
+        db.SubscribeDeptToLabelResult.Success,
+    );
+    expect(await db.subscribeDeptToLabel(did, coolLabel)).toStrictEqual(
+        db.SubscribeDeptToLabelResult.Exists,
+    );
 });
 
 it('should reject promoting non-existent users', async () => {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1,10 +1,10 @@
 import { type Agent, AgentSchema } from '$lib/model/agent';
-import { type Dept, DeptSchema } from '$lib/model/dept';
+import { type Dept, type DeptLabel, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
 import { type Message, type Ticket, type TicketLabel, TicketSchema } from '$lib/model/ticket';
 import { type Pending, PendingSchema, type Session } from '$lib/server/model/session';
 import { type Priority, PrioritySchema } from '$lib/model/priority';
-import { UnexpectedConstraintName, UnexpectedRowCount, UnexpectedTableName } from './error';
+import { UnexpectedConstraintName, UnexpectedErrorCode, UnexpectedRowCount, UnexpectedTableName } from './error';
 import { type User, UserSchema } from '$lib/model/user';
 import { default as assert, strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
@@ -294,6 +294,51 @@ export async function setHeadForAgent(
         await sql`SELECT * FROM set_head_for_agent(${did}, ${uid}, ${head}) AS head WHERE head IS NOT NULL`.execute();
     strictEqual(rest.length, 0);
     return typeof first === 'undefined' ? null : AgentSchema.pick({ head: true }).parse(first).head;
+}
+
+export enum SubscribeDeptToLabelResult {
+    /** Subscription successfully added. */
+    Success,
+    /** Subscription already exists. No action taken. */
+    Exists,
+    /** Provided {@linkcode Dept} does not exist. */
+    NoDept,
+    /** Provided {@linkcode Label} does not exist. */
+    NoLabel,
+}
+
+/** Opts in a {@linkcode Dept} to a {@linkcode Label}. */
+export async function subscribeDeptToLabel(did: DeptLabel['dept_id'], lid: DeptLabel['label_id']) {
+    try {
+        const { count } = await sql`SELECT subscribe_dept_to_label(${did}, ${lid})`;
+        strictEqual(count, 1);
+        return SubscribeDeptToLabelResult.Success;
+    } catch (err) {
+        const isExpected = err instanceof pg.PostgresError;
+        if (!isExpected) throw err;
+
+        const { code, table_name, constraint_name } = err;
+        strictEqual(table_name, 'dept_labels');
+
+        switch (code) {
+            case '23503':
+                switch (constraint_name) {
+                    case 'dept_labels_dept_id_fkey':
+                        return SubscribeDeptToLabelResult.NoDept;
+                    case 'dept_labels_label_id_fkey':
+                        return SubscribeDeptToLabelResult.NoLabel;
+                    default:
+                        assert(constraint_name);
+                        throw new UnexpectedConstraintName(constraint_name);
+                }
+            case '23505':
+                strictEqual(constraint_name, 'dept_labels_pkey');
+                return SubscribeDeptToLabelResult.Exists;
+            default:
+                throw new UnexpectedErrorCode(code);
+        }
+
+    }
 }
 
 export const enum CreateTicketResult {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -4,7 +4,12 @@ import { type Label, LabelSchema } from '$lib/model/label';
 import { type Message, type Ticket, type TicketLabel, TicketSchema } from '$lib/model/ticket';
 import { type Pending, PendingSchema, type Session } from '$lib/server/model/session';
 import { type Priority, PrioritySchema } from '$lib/model/priority';
-import { UnexpectedConstraintName, UnexpectedErrorCode, UnexpectedRowCount, UnexpectedTableName } from './error';
+import {
+    UnexpectedConstraintName,
+    UnexpectedErrorCode,
+    UnexpectedRowCount,
+    UnexpectedTableName,
+} from './error';
 import { type User, UserSchema } from '$lib/model/user';
 import { default as assert, strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
@@ -337,7 +342,6 @@ export async function subscribeDeptToLabel(did: DeptLabel['dept_id'], lid: DeptL
             default:
                 throw new UnexpectedErrorCode(code);
         }
-
     }
 }
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -142,7 +142,7 @@ export async function editLabelTitle(lid: Label['label_id'], title: Label['title
         case 1:
             return true;
         default:
-            throw new UnexpectedRowCount();
+            throw new UnexpectedRowCount(count);
     }
 }
 
@@ -156,7 +156,7 @@ export async function editLabelColor(lid: Label['label_id'], color: Label['color
         case 1:
             return true;
         default:
-            throw new UnexpectedRowCount();
+            throw new UnexpectedRowCount(count);
     }
 }
 
@@ -171,7 +171,7 @@ export async function editLabelDeadline(lid: Label['label_id'], days: Label['dea
         case 1:
             return true;
         default:
-            throw new UnexpectedRowCount();
+            throw new UnexpectedRowCount(count);
     }
 }
 
@@ -193,7 +193,7 @@ export async function editPriorityTitle(pid: Priority['priority_id'], title: Pri
         case 1:
             return true;
         default:
-            throw new UnexpectedRowCount();
+            throw new UnexpectedRowCount(count);
     }
 }
 
@@ -210,7 +210,7 @@ export async function editPriorityLevel(
         case 1:
             return true;
         default:
-            throw new UnexpectedRowCount();
+            throw new UnexpectedRowCount(count);
     }
 }
 
@@ -230,7 +230,7 @@ export async function editDeptName(did: Dept['dept_id'], name: Dept['name']) {
         case 1:
             return true;
         default:
-            throw new UnexpectedRowCount();
+            throw new UnexpectedRowCount(count);
     }
 }
 
@@ -258,7 +258,7 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
             case 1:
                 return AddDeptAgentResult.Success;
             default:
-                throw new UnexpectedRowCount();
+                throw new UnexpectedRowCount(count);
         }
     } catch (err) {
         const isExpected = err instanceof pg.PostgresError;

--- a/src/routes/api/dept/label/+server.ts
+++ b/src/routes/api/dept/label/+server.ts
@@ -1,0 +1,51 @@
+import { SubscribeDeptToLabelResult, isHeadSession, subscribeDeptToLabel } from '$lib/server/database';
+import { error } from '@sveltejs/kit';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+
+function resultToCode(result: SubscribeDeptToLabelResult) {
+    switch (result) {
+        case SubscribeDeptToLabelResult.Success:
+            return StatusCodes.CREATED;
+        case SubscribeDeptToLabelResult.Exists:
+            return StatusCodes.CONFLICT;
+        case SubscribeDeptToLabelResult.NoLabel:
+        case SubscribeDeptToLabelResult.NoDept:
+            return StatusCodes.NOT_FOUND;
+        default:
+            throw new AssertionError();
+    }
+}
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const dept = form.get('dept');
+    if (dept === null || dept instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const did = parseInt(dept, 10);
+
+    const label = form.get('label');
+    if (label === null || label instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const lid = parseInt(dept, 10);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: session has expired so we must inform the client that they should log in again
+    const admin = await isHeadSession(sid, did);
+    switch (admin) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+        default:
+            throw new AssertionError();
+    }
+
+    const status = resultToCode(await subscribeDeptToLabel(did, lid));
+    return new Response(null, { status });
+};

--- a/src/routes/api/dept/label/+server.ts
+++ b/src/routes/api/dept/label/+server.ts
@@ -1,4 +1,8 @@
-import { SubscribeDeptToLabelResult, isHeadSession, subscribeDeptToLabel } from '$lib/server/database';
+import {
+    SubscribeDeptToLabelResult,
+    isHeadSession,
+    subscribeDeptToLabel,
+} from '$lib/server/database';
 import { error } from '@sveltejs/kit';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';

--- a/src/routes/api/dept/label/+server.ts
+++ b/src/routes/api/dept/label/+server.ts
@@ -3,10 +3,10 @@ import {
     isHeadSession,
     subscribeDeptToLabel,
 } from '$lib/server/database';
-import { error } from '@sveltejs/kit';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
 
 function resultToCode(result: SubscribeDeptToLabelResult) {
     switch (result) {


### PR DESCRIPTION
This PR implements the new endpoint `POST /api/dept/label`, which subscribes a `Dept` to a subset of the available system `Label`s (as added by `POST /api/label`). In an actual form, the user creates a new ticket by indicating its "category". The labels that will be shown in the dropdown menu will be determined by the labels that a department _does_ subscribe to.

When the ticket is created, all subscribed departments are automatically assigned to the ticket. Any agent from the respective departments may now volunteer the assignment or be assigned to the ticket by some department head.