### PR TITLE
feat(api): implement reply creation

### DIFF
--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -1,9 +1,12 @@
 import { BadInput, InvalidSession, UnexpectedStatusCode } from './error';
-import { type Message, type Ticket, TicketSchema } from '$lib/model/ticket';
+import { CreateTicketSchema, type Message, type Ticket } from '$lib/model/ticket';
 import type { Label } from '$lib/model/label';
 import { StatusCodes } from 'http-status-codes';
 
-/** Creates a new {@linkcode Ticket} and returns its `ticket_id` if successful. */
+/**
+ * Creates a new {@linkcode Ticket} and returns its `ticket_id` as `tid` and its the `message_id`
+ * as `mid`. The `mid` points to the first {@linkcode Message} in the ticket's conversation thread.
+ */
 export async function create(
     title: Ticket['title'],
     content: Message['body'],
@@ -24,7 +27,7 @@ export async function create(
 
     switch (res.status) {
         case StatusCodes.CREATED:
-            return TicketSchema.shape.ticket_id.parse(await res.text());
+            return CreateTicketSchema.parse(await res.json());
         case StatusCodes.NOT_FOUND:
             return null;
         case StatusCodes.BAD_REQUEST:

--- a/src/lib/model/ticket.ts
+++ b/src/lib/model/ticket.ts
@@ -27,6 +27,7 @@ export const MessageSchema = z.object({
 export const CreateTicketSchema = z.object({
     tid: TicketSchema.shape.ticket_id,
     mid: MessageSchema.shape.message_id,
+    due: TicketSchema.shape.due_date,
 });
 
 export type Ticket = z.infer<typeof TicketSchema>;

--- a/src/lib/model/ticket.ts
+++ b/src/lib/model/ticket.ts
@@ -16,7 +16,7 @@ export const TicketLabelSchema = z.object({
     label_id: LabelSchema.shape.label_id,
 });
 
-export const Message = z.object({
+export const MessageSchema = z.object({
     author_id: UserSchema.shape.user_id,
     ticket_id: TicketSchema.shape.ticket_id,
     message_id: z.number().int().positive(),
@@ -24,6 +24,13 @@ export const Message = z.object({
     body: z.string().max(1024),
 });
 
+export const CreateTicketSchema = z.object({
+    tid: TicketSchema.shape.ticket_id,
+    mid: MessageSchema.shape.message_id,
+});
+
 export type Ticket = z.infer<typeof TicketSchema>;
 export type TicketLabel = z.infer<typeof TicketLabelSchema>;
-export type Message = z.infer<typeof Message>;
+export type Message = z.infer<typeof MessageSchema>;
+
+export type CreateTicket = z.infer<typeof CreateTicketSchema>;

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -128,7 +128,7 @@ it('should complete a full user journey', async () => {
             nonExistentUser,
             'No Ticket and User',
         );
-        expect(result).toStrictEqual(db.CreateReplyResult.NoUser);
+        expect(result).toStrictEqual(db.CreateReplyResult.NoTicket);
     }
 
     // Valid user with labels

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -1,5 +1,5 @@
 import * as db from '.';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, assert, describe, expect, it } from 'vitest';
 import { getRandomValues, randomUUID } from 'node:crypto';
 
 afterAll(() => db.end());
@@ -83,8 +83,18 @@ it('should complete a full user journey', async () => {
     {
         // Valid user with no labels
         const result = await db.createTicket('No Labels', uid, 'oof', []);
-        expect(typeof result).toStrictEqual('string');
+        assert(typeof result === 'object');
+        const { tid, mid } = result;
+        expect(tid).toHaveLength(36);
+        expect(mid).not.toStrictEqual(0);
     }
+
+    // Valid user with labels
+    const createTicketResult = await db.createTicket('With Label', uid, 'yay!', [coolLabel]);
+    assert(typeof createTicketResult === 'object');
+    const { tid, mid } = createTicketResult;
+    expect(tid).toHaveLength(36);
+    expect(mid).not.toStrictEqual(0);
 
     const coolLabel = await db.createLabel('Cool', 0xc0debeef);
 
@@ -93,10 +103,6 @@ it('should complete a full user journey', async () => {
         const result = await db.createTicket('Invalid User', nonExistentUser, 'oof', [coolLabel]);
         expect(result).toStrictEqual(db.CreateTicketResult.NoAuthor);
     }
-
-    // Valid user with labels
-    const tid = await db.createTicket('With Label', uid, 'yay!', [coolLabel]);
-    expect(typeof tid).toStrictEqual('string');
 
     expect(await db.subscribeDeptToLabel(0, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -84,9 +84,10 @@ it('should complete a full user journey', async () => {
         // Valid user with no labels
         const result = await db.createTicket('No Labels', uid, 'oof', []);
         assert(typeof result === 'object');
-        const { tid, mid } = result;
+        const { tid, mid, due } = result;
         expect(tid).toHaveLength(36);
         expect(mid).not.toStrictEqual(0);
+        expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
     }
 
     const coolLabel = await db.createLabel('Cool', 0xc0debeef);
@@ -133,9 +134,10 @@ it('should complete a full user journey', async () => {
     // Valid user with labels
     const createTicketResult = await db.createTicket('With Label', uid, 'yay!', [coolLabel]);
     assert(typeof createTicketResult === 'object');
-    const { tid, mid } = createTicketResult;
+    const { tid, mid, due } = createTicketResult;
     expect(tid).toHaveLength(36);
     expect(mid).not.toStrictEqual(0);
+    expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
     {
         const result = await db.createReply(tid, nonExistentUser, 'No User');

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -365,7 +365,7 @@ export async function createTicket(
 ) {
     try {
         const [first, ...rest] =
-            await sql`SELECT tid, mid FROM create_ticket(${title}, ${author}, ${body}, ${labels})`.execute();
+            await sql`SELECT tid, mid, LEAST(due, to_timestamp(8640000000000)) AS due FROM create_ticket(${title}, ${author}, ${body}, ${labels})`.execute();
         strictEqual(rest.length, 0);
         return CreateTicketSchema.parse(first);
     } catch (err) {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -17,7 +17,7 @@ import {
     UnexpectedTableName,
 } from './error';
 import { type User, UserSchema } from '$lib/model/user';
-import { default as assert, strictEqual } from 'node:assert/strict';
+import assert, { strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
 import env from '$lib/server/env/postgres';
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -435,15 +435,15 @@ export async function createReply(
         const isExpected = err instanceof pg.PostgresError;
         if (!isExpected) throw err;
 
-        const { code, table_name, constraint_name } = err;
-        strictEqual(code, '23503');
-        strictEqual(table_name, 'messages');
-
-        switch (constraint_name) {
-            case 'messages_ticket_id_fkey':
-                return CreateReplyResult.NoTicket;
-            case 'messages_author_id_fkey':
+        const { code, table_name, constraint_name, routine } = err;
+        switch (code) {
+            case '23503':
+                strictEqual(table_name, 'messages');
+                strictEqual(constraint_name, 'messages_author_id_fkey');
                 return CreateReplyResult.NoUser;
+            case 'P0004':
+                strictEqual(routine, 'exec_stmt_assert');
+                return CreateReplyResult.NoTicket;
             default:
                 assert(constraint_name);
                 throw new UnexpectedConstraintName(constraint_name);

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1,7 +1,7 @@
 import { type Agent, AgentSchema } from '$lib/model/agent';
+import { CreateTicketSchema, type Message, type Ticket, type TicketLabel } from '$lib/model/ticket';
 import { type Dept, type DeptLabel, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
-import { type Message, type Ticket, type TicketLabel, TicketSchema } from '$lib/model/ticket';
 import { type Pending, PendingSchema, type Session } from '$lib/server/model/session';
 import { type Priority, PrioritySchema } from '$lib/model/priority';
 import {
@@ -14,8 +14,6 @@ import { type User, UserSchema } from '$lib/model/user';
 import { default as assert, strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
 import env from '$lib/server/env/postgres';
-
-export { UnexpectedRowCount };
 
 class Transaction {
     #sql: TransactionSql;
@@ -361,9 +359,9 @@ export async function createTicket(
 ) {
     try {
         const [first, ...rest] =
-            await sql`SELECT create_ticket(${title}, ${author}, ${body}, ${labels}) AS ticket_id`;
+            await sql`SELECT tid, mid FROM create_ticket(${title}, ${author}, ${body}, ${labels})`;
         strictEqual(rest.length, 0);
-        return TicketSchema.pick({ ticket_id: true }).parse(first).ticket_id;
+        return CreateTicketSchema.parse(first);
     } catch (err) {
         const isExpected = err instanceof pg.PostgresError;
         if (!isExpected) throw err;

--- a/src/routes/api/ticket/+server.ts
+++ b/src/routes/api/ticket/+server.ts
@@ -1,8 +1,8 @@
 import { CreateTicketResult, createTicket, getUserFromSession } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
-import { error } from '@sveltejs/kit';
 
 // eslint-disable-next-line func-style
 export const POST: RequestHandler = async ({ cookies, request }) => {
@@ -26,7 +26,7 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
     if (user === null) throw error(StatusCodes.UNAUTHORIZED);
 
     const result = await createTicket(title, user.user_id, body, labels);
-    if (typeof result === 'string') return new Response(result, { status: StatusCodes.CREATED });
+    if (typeof result === 'object') return json(result, { status: StatusCodes.CREATED });
 
     switch (result) {
         case CreateTicketResult.NoAuthor:

--- a/src/routes/api/ticket/reply/+server.ts
+++ b/src/routes/api/ticket/reply/+server.ts
@@ -1,0 +1,33 @@
+import { CreateReplyResult, createReply, getUserFromSession } from '$lib/server/database';
+import { error, json } from '@sveltejs/kit';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const tid = form.get('ticket');
+    if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const body = form.get('body');
+    if (body === null || body instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+
+    const result = await createReply(tid, user.user_id, body);
+    if (typeof result === 'number') return json(result, { status: StatusCodes.CREATED });
+
+    switch (result) {
+        case CreateReplyResult.NoUser:
+        case CreateReplyResult.NoTicket:
+            return new Response(null, { status: StatusCodes.NOT_FOUND });
+        default:
+            throw new AssertionError();
+    }
+};

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,6 +1,6 @@
 import { AuthorizationCode, IdTokenSchema, TokenResponseSchema } from '$lib/server/model/google';
 import { HeaderSchema, fetchCerts, fetchDiscoveryDocument } from '$lib/server/model/openid';
-import { default as assert, ok, strictEqual } from 'node:assert/strict';
+import assert, { ok, strictEqual } from 'node:assert/strict';
 import { error, redirect } from '@sveltejs/kit';
 import { hash, load } from 'blake3';
 import type { RequestHandler } from './$types';


### PR DESCRIPTION
This PR adds a new endpoint `POST /api/ticket/reply`, which submits a new reply to an existing ticket.