### PR TITLE
feat(api): implement editing of ticket title

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -315,3 +315,11 @@ TYPE AS $$
     WITH _ AS (SELECT author_id, MIN(creation) FROM messages WHERE ticket_id = tid GROUP BY author_id)
         SELECT author_id FROM _;
 $$ LANGUAGE SQL;
+
+CREATE FUNCTION get_assigned_agents (
+    tid assignments.ticket_id %
+    TYPE
+) RETURNS SETOF assignments.user_id %
+TYPE AS $$
+    SELECT user_id FROM assignments WHERE ticket_id = tid;
+$$ LANGUAGE SQL;

--- a/db/init.sql
+++ b/db/init.sql
@@ -306,3 +306,12 @@ BEGIN
     RETURN QUERY SELECT tid, mid, due;
 END;
 $$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION get_ticket_author (
+    tid tickets.ticket_id %
+    TYPE
+) RETURNS messages.author_id %
+TYPE AS $$
+    WITH _ AS (SELECT author_id, MIN(creation) FROM messages WHERE ticket_id = tid GROUP BY author_id)
+        SELECT author_id FROM _;
+$$ LANGUAGE SQL;

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -39,13 +39,12 @@ export async function create(
     }
 }
 /** Edits the `title` field of a {@linkcode Ticket}. Returns `false` if not found. */
-export async function editTitle(tid: Ticket['ticket_id'], title: Ticket['title']) {
+export async function editTitle(id: Ticket['ticket_id'], title: Ticket['title']) {
     const { status } = await fetch('/api/ticket/title', {
         method: 'PATCH',
         credentials: 'same-origin',
-        body: new URLSearchParams({ id: tid, title }),
+        body: new URLSearchParams({ id, title }),
     });
-
     switch (status) {
         case StatusCodes.NO_CONTENT:
             return true;

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -1,4 +1,4 @@
-import { BadInput, InvalidSession, UnexpectedStatusCode } from './error';
+import { BadInput, InsufficientPermissions, InvalidSession, UnexpectedStatusCode } from './error';
 import { CreateTicketSchema, type Message, MessageSchema, type Ticket } from '$lib/model/ticket';
 import type { Label } from '$lib/model/label';
 import { StatusCodes } from 'http-status-codes';
@@ -36,6 +36,29 @@ export async function create(
             throw new InvalidSession();
         default:
             throw new UnexpectedStatusCode(res.status);
+    }
+}
+/** Edits the `title` field of a {@linkcode Ticket}. Returns `false` if not found. */
+export async function editTitle(tid: Ticket['ticket_id'], title: Ticket['title']) {
+    const { status } = await fetch('/api/ticket/title', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ id: tid, title }),
+    });
+
+    switch (status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.NOT_FOUND:
+            return false;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
     }
 }
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -90,8 +90,8 @@ it('should complete a full user journey', async () => {
         expect(mid).not.toStrictEqual(0);
         expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
-        expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toStrictEqual(null);
-        expect(await db.isTicketAuthor(nonExistentTicket, uid)).toStrictEqual(null);
+        expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toBeNull();
+        expect(await db.isTicketAuthor(nonExistentTicket, uid)).toBeNull();
         expect(await db.isTicketAuthor(tid, nonExistentUser)).toStrictEqual(false);
         expect(await db.isTicketAuthor(tid, uid)).toStrictEqual(true);
     }
@@ -113,7 +113,12 @@ it('should complete a full user journey', async () => {
         expect(mid).not.toStrictEqual(0);
         expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
-        expect(await db.editTicketTitle(tid, 'New title')).toStrictEqual(true);
+        expect(await db.canEditTicketTitle(nonExistentTicket, nonExistentUser)).toBeNull();
+        expect(await db.canEditTicketTitle(nonExistentTicket, uid)).toBeNull();
+        expect(await db.canEditTicketTitle(tid, nonExistentUser)).toStrictEqual(false);
+        expect(await db.canEditTicketTitle(tid, uid)).toStrictEqual(true);
+        // TODO: add test case when the agent actually does have permission
+        expect(await db.editTicketTitle(tid, 'New Title')).toStrictEqual(true);
     }
 
     expect(await db.subscribeDeptToLabel(0, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -80,6 +80,7 @@ it('should complete a full user journey', async () => {
         expect(result).toStrictEqual(db.CreateTicketResult.NoLabels);
     }
 
+    const nonExistentTicket = randomUUID();
     {
         // Valid user with no labels
         const result = await db.createTicket('No Labels', uid, 'oof', []);
@@ -88,6 +89,11 @@ it('should complete a full user journey', async () => {
         expect(tid).toHaveLength(36);
         expect(mid).not.toStrictEqual(0);
         expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
+
+        expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toStrictEqual(null);
+        expect(await db.isTicketAuthor(nonExistentTicket, uid)).toStrictEqual(null);
+        expect(await db.isTicketAuthor(tid, nonExistentUser)).toStrictEqual(false);
+        expect(await db.isTicketAuthor(tid, uid)).toStrictEqual(true);
     }
 
     const coolLabel = await db.createLabel('Cool', 0xc0debeef);
@@ -132,8 +138,6 @@ it('should complete a full user journey', async () => {
         expect(result).toStrictEqual(db.SubscribeDeptToLabelResult.Exists);
     }
 
-    const nonExistentTicket = randomUUID();
-
     {
         const result = await db.createReply(
             nonExistentTicket,
@@ -150,6 +154,11 @@ it('should complete a full user journey', async () => {
     expect(tid).toHaveLength(36);
     expect(mid).not.toStrictEqual(0);
     expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
+
+    expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toStrictEqual(null);
+    expect(await db.isTicketAuthor(nonExistentTicket, uid)).toStrictEqual(null);
+    expect(await db.isTicketAuthor(tid, nonExistentUser)).toStrictEqual(false);
+    expect(await db.isTicketAuthor(tid, uid)).toStrictEqual(true);
 
     {
         const result = await db.createReply(tid, nonExistentUser, 'No User');

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -98,6 +98,18 @@ it('should complete a full user journey', async () => {
         expect(result).toStrictEqual(db.CreateTicketResult.NoAuthor);
     }
 
+    {
+        // Create ticket and edit its title
+        const result = await db.createTicket('Old title', uid, 'Hello World', [coolLabel]);
+        assert(typeof result === 'object');
+        const { tid, mid, due } = result;
+        expect(tid).toHaveLength(36);
+        expect(mid).not.toStrictEqual(0);
+        expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
+
+        expect(await db.editTicketTitle(tid, 'New title')).toStrictEqual(true);
+    }
+
     expect(await db.subscribeDeptToLabel(0, 0)).toStrictEqual(db.SubscribeDeptToLabelResult.NoDept);
 
     {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -20,6 +20,7 @@ import { type User, UserSchema } from '$lib/model/user';
 import assert, { strictEqual } from 'node:assert/strict';
 import pg, { type TransactionSql } from 'postgres';
 import env from '$lib/server/env/postgres';
+import { z } from 'zod';
 
 class Transaction {
     #sql: TransactionSql;
@@ -408,6 +409,13 @@ export async function createTicket(
         assert(constraint_name);
         throw new UnexpectedConstraintName(constraint_name);
     }
+}
+
+export async function isTicketAuthor(tid: Ticket['ticket_id'], uid: Message['author_id']) {
+    const [first, ...rest] =
+        await sql`SELECT get_ticket_author(${tid}) = ${uid} AS result`.execute();
+    strictEqual(rest.length, 0);
+    return z.object({ result: z.boolean().nullable() }).parse(first).result;
 }
 
 /** Edits the `title` field of a {@linkcode Ticket}. Returns `false` if not found. */

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -275,11 +275,7 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
 
         const { code, table_name, constraint_name } = err;
         strictEqual(code, '23503');
-
-        if (table_name !== 'dept_agents') {
-            assert(table_name);
-            throw new UnexpectedTableName(table_name);
-        }
+        strictEqual(table_name, 'dept_agents');
 
         switch (constraint_name) {
             case 'dept_agents_dept_id_fkey':

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -414,6 +414,20 @@ export async function createTicket(
     }
 }
 
+/** Edits the `title` field of a {@linkcode Ticket}. Returns `false` if not found. */
+export async function editTicketTitle(tid: Ticket['ticket_id'], title: Ticket['title']) {
+    const { count } =
+        await sql`UPDATE tickets SET title = ${title} WHERE ticket_id = ${tid}`.execute();
+    switch (count) {
+        case 0:
+            return false;
+        case 1:
+            return true;
+        default:
+            throw new UnexpectedRowCount(count);
+    }
+}
+
 export const enum CreateReplyResult {
     /** The provided {@linkcode Ticket} does not exist. */
     NoTicket = '0',

--- a/src/routes/api/ticket/title/+server.ts
+++ b/src/routes/api/ticket/title/+server.ts
@@ -1,0 +1,24 @@
+import type { RequestHandler } from '../$types';
+import { StatusCodes } from 'http-status-codes';
+import { editTicketTitle } from '$lib/server/database';
+import { error } from '@sveltejs/kit';
+
+// eslint-disable-next-line func-style
+export const PATCH: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const tid = form.get('id');
+    if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const title = form.get('title');
+    if (title === null || title instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: Missing a permission check. Editing should only be allowed for the ticket author and agents assigned to the ticket.
+
+    const success = await editTicketTitle(tid, title);
+    const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;
+    return new Response(null, { status });
+};


### PR DESCRIPTION
This PR implements editing the `title` field of an existing ticket.

> **Warning**
> The current implementation does not do any permission checks. Ideally, editing the ticket title should only be allowed for the ticket author and assigned agents.