### PR TITLE
feat(api): implement removal of department agents

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -227,6 +227,16 @@ CREATE FUNCTION add_dept_agent (
     INSERT INTO dept_agents (dept_id, user_id) VALUES (did, uid) ON CONFLICT (dept_id, user_id) DO NOTHING;
 $$ LANGUAGE SQL;
 
+CREATE FUNCTION remove_dept_agent (
+    did dept_agents.dept_id %
+    TYPE,
+    uid dept_agents.user_id %
+    TYPE
+) RETURNS dept_agents.head %
+TYPE AS $$
+    DELETE FROM dept_agents WHERE dept_id = did AND user_id = uid RETURNING head;
+$$ LANGUAGE SQL;
+
 CREATE FUNCTION set_head_for_agent (
     did dept_agents.dept_id %
     TYPE,

--- a/db/init.sql
+++ b/db/init.sql
@@ -78,7 +78,7 @@ CREATE TABLE
         dept_id SERIAL NOT NULL,
         user_id GoogleUserId,
         PRIMARY KEY (ticket_id, dept_id, user_id),
-        FOREIGN KEY (dept_id, user_id) REFERENCES dept_agents (dept_id, user_id)
+        FOREIGN KEY (dept_id, user_id) REFERENCES dept_agents (dept_id, user_id) ON DELETE CASCADE
     );
 
 CREATE TABLE

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -8,12 +8,12 @@ import type { User } from '$lib/model/user';
  * Adds a new {@linkcode User} to a {@linkcode Dept}. Returns `true` if successful, `false` if the
  * {@linkcode Agent} already exists, and `null` if either the department or the user is not found.
  */
-export async function add(dept_id: Dept['dept_id'], uid: User['user_id'], head: Agent['head']) {
+export async function add(did: Dept['dept_id'], uid: User['user_id'], head: Agent['head']) {
     const { status } = await fetch('/api/agent', {
         method: 'POST',
         credentials: 'same-origin',
         body: new URLSearchParams({
-            did: dept_id.toString(10),
+            did: did.toString(10),
             uid,
             head: Number(head).toString(10),
         }),
@@ -37,12 +37,12 @@ export async function add(dept_id: Dept['dept_id'], uid: User['user_id'], head: 
 }
 
 /** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns `true` if successful, `false` otherwise. */
-export async function remove(dept_id: Agent['dept_id'], uid: Agent['user_id']) {
+export async function remove(did: Agent['dept_id'], uid: Agent['user_id']) {
     const { status } = await fetch('/api/agent', {
         method: 'DELETE',
         credentials: 'same-origin',
         body: new URLSearchParams({
-            did: dept_id.toString(10),
+            did: did.toString(10),
             uid,
         }),
     });

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -36,7 +36,9 @@ export async function add(did: Dept['dept_id'], uid: User['user_id'], head: Agen
     }
 }
 
-/** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns `true` if successful, `false` otherwise. */
+/** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns the `head` value 
+ *  of the deleted agent or `null` if either the department or the user is not found.
+ */
 export async function remove(did: Agent['dept_id'], uid: Agent['user_id']) {
     const { status } = await fetch('/api/agent', {
         method: 'DELETE',

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -37,7 +37,7 @@ export async function add(dept_id: Dept['dept_id'], uid: User['user_id'], head: 
 }
 
 /** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns `true` if successful, `false` otherwise. */
-export async function remove(did: Agent['dept_id'], uid: Agent['user_id']) {
+export async function remove(dept_id: Agent['dept_id'], uid: Agent['user_id']) {
     const { status } = await fetch('/api/agent', {
         method: 'DELETE',
         credentials: 'same-origin',
@@ -48,9 +48,11 @@ export async function remove(did: Agent['dept_id'], uid: Agent['user_id']) {
     });
     switch (status) {
         case StatusCodes.NO_CONTENT:
+            return false;
+        case StatusCodes.RESET_CONTENT:
             return true;
         case StatusCodes.NOT_FOUND:
-            return false;
+            return null;
         case StatusCodes.BAD_REQUEST:
             throw new BadInput();
         case StatusCodes.UNAUTHORIZED:

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -36,6 +36,32 @@ export async function add(dept_id: Dept['dept_id'], uid: User['user_id'], head: 
     }
 }
 
+/** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns `true` if successful, `false` otherwise. */
+export async function remove(dept_id: Agent['dept_id'], uid: Agent['user_id']) {
+    const { status } = await fetch('/api/agent', {
+        method: 'DELETE',
+        credentials: 'same-origin',
+        body: new URLSearchParams({
+            did: dept_id.toString(10),
+            uid,
+        }),
+    });
+    switch (status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.NOT_FOUND:
+            return false;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
+    }
+}
+
 /** Promotes a {@linkcode User} as the head of the {@linkcode Dept}. */
 export async function setHead(
     dept_id: Agent['dept_id'],

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -36,8 +36,9 @@ export async function add(did: Dept['dept_id'], uid: User['user_id'], head: Agen
     }
 }
 
-/** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns the `head` value 
- *  of the deleted agent or `null` if either the department or the user is not found.
+/**
+ * Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns the `head` value
+ * of the deleted agent or `null` if either the department or the user is not found.
  */
 export async function remove(did: Agent['dept_id'], uid: Agent['user_id']) {
     const { status } = await fetch('/api/agent', {

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -37,7 +37,7 @@ export async function add(dept_id: Dept['dept_id'], uid: User['user_id'], head: 
 }
 
 /** Removes an {@linkcode Agent} from the {@linkcode Dept}. Returns `true` if successful, `false` otherwise. */
-export async function remove(dept_id: Agent['dept_id'], uid: Agent['user_id']) {
+export async function remove(did: Agent['dept_id'], uid: Agent['user_id']) {
     const { status } = await fetch('/api/agent', {
         method: 'DELETE',
         credentials: 'same-origin',

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -62,10 +62,10 @@ it('should complete a full user journey', async () => {
     expect(await db.addDeptAgent(0, uid)).toStrictEqual(db.AddDeptAgentResult.NoDept);
     expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.Success);
 
-    expect(await db.removeDeptAgent(0, nonExistentUser)).toStrictEqual(false);
-    expect(await db.removeDeptAgent(did, nonExistentUser)).toStrictEqual(false);
-    expect(await db.removeDeptAgent(0, uid)).toStrictEqual(false);
-    expect(await db.removeDeptAgent(did, uid)).toStrictEqual(true);
+    expect(await db.removeDeptAgent(0, nonExistentUser)).toBeNull();
+    expect(await db.removeDeptAgent(did, nonExistentUser)).toBeNull();
+    expect(await db.removeDeptAgent(0, uid)).toBeNull();
+    expect(await db.removeDeptAgent(did, uid)).toStrictEqual(false);
     expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.Success);
 
     expect(await db.isHeadSession(session_id, did)).toStrictEqual(false);

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -62,6 +62,12 @@ it('should complete a full user journey', async () => {
     expect(await db.addDeptAgent(0, uid)).toStrictEqual(db.AddDeptAgentResult.NoDept);
     expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.Success);
 
+    expect(await db.removeDeptAgent(0, nonExistentUser)).toStrictEqual(false);
+    expect(await db.removeDeptAgent(did, nonExistentUser)).toStrictEqual(false);
+    expect(await db.removeDeptAgent(0, uid)).toStrictEqual(false);
+    expect(await db.removeDeptAgent(did, uid)).toStrictEqual(true);
+    expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.Success);
+
     expect(await db.isHeadSession(session_id, did)).toStrictEqual(false);
     expect(await db.setHeadForAgent(did, uid, true)).toStrictEqual(false);
     expect(await db.isHeadSession(session_id, did)).toStrictEqual(true);

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -296,7 +296,8 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
  * Removes an {@linkcode Agent} user from the dept_agents table. Returns false if dept-user combo not found.
  */
 export async function removeDeptAgent(did: Agent['dept_id'], uid: Agent['user_id']) {
-    const { count } = await sql`DELETE FROM dept_agents WHERE dept_id = ${did} AND user_id = ${uid}`.execute();
+    const { count } =
+        await sql`DELETE FROM dept_agents WHERE dept_id = ${did} AND user_id = ${uid}`.execute();
     switch (count) {
         case 0:
             return false;

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -296,16 +296,10 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
  * Removes an {@linkcode Agent} user from the dept_agents table. Returns false if dept-user combo not found.
  */
 export async function removeDeptAgent(did: Agent['dept_id'], uid: Agent['user_id']) {
-    const { count } =
-        await sql`DELETE FROM dept_agents WHERE dept_id = ${did} AND user_id = ${uid}`.execute();
-    switch (count) {
-        case 0:
-            return false;
-        case 1:
-            return true;
-        default:
-            throw new UnexpectedRowCount(count);
-    }
+    const [first, ...rest] =
+        await sql`DELETE FROM dept_agents WHERE dept_id = ${did} AND user_id = ${uid} RETURNING head`.execute();
+    strictEqual(rest.length, 0);
+    return typeof first === 'undefined' ? null : AgentSchema.pick({ head: true }).parse(first).head;
 }
 
 /** Promotes a {@linkcode Agent} to a department head. Returns `true` if already a department head. */

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -293,11 +293,12 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
 }
 
 /**
- * Removes an {@linkcode Agent} user from the dept_agents table. Returns false if dept-user combo not found.
+ * Removes an {@linkcode Agent} user from the dept_agents table. Returns the `head` value of the removed agent
+ * if successful or `null` if the department-user pair is not found in the table.
  */
 export async function removeDeptAgent(did: Agent['dept_id'], uid: Agent['user_id']) {
     const [first, ...rest] =
-        await sql`DELETE FROM dept_agents WHERE dept_id = ${did} AND user_id = ${uid} RETURNING head`.execute();
+        await sql`SELECT * FROM remove_dept_agent(${did}, ${uid}) AS head WHERE head is NOT NULL`.execute();
     strictEqual(rest.length, 0);
     return typeof first === 'undefined' ? null : AgentSchema.pick({ head: true }).parse(first).head;
 }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -292,6 +292,21 @@ export async function addDeptAgent(did: Agent['dept_id'], uid: Agent['user_id'])
     }
 }
 
+/**
+ * Removes an {@linkcode Agent} user from the dept_agents table. Returns false if dept-user combo not found.
+ */
+export async function removeDeptAgent(did: Agent['dept_id'], uid: Agent['user_id']) {
+    const { count } = await sql`DELETE FROM dept_agents WHERE dept_id = ${did} AND user_id = ${uid}`.execute();
+    switch (count) {
+        case 0:
+            return false;
+        case 1:
+            return true;
+        default:
+            throw new UnexpectedRowCount(count);
+    }
+}
+
 /** Promotes a {@linkcode Agent} to a department head. Returns `true` if already a department head. */
 export async function setHeadForAgent(
     did: Agent['dept_id'],

--- a/src/routes/api/agent/+server.ts
+++ b/src/routes/api/agent/+server.ts
@@ -82,7 +82,9 @@ export const DELETE: RequestHandler = async ({ cookies, request }) => {
             throw new AssertionError();
     }
 
-    const success = await removeDeptAgent(did, uid);
-    const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;
+    const value = await removeDeptAgent(did, uid);
+    if (value === null) return new Response(null, { status: StatusCodes.NOT_FOUND });
+
+    const status = value ? StatusCodes.RESET_CONTENT : StatusCodes.NO_CONTENT;
     return new Response(null, { status });
 };

--- a/src/routes/api/agent/+server.ts
+++ b/src/routes/api/agent/+server.ts
@@ -1,4 +1,9 @@
-import { AddDeptAgentResult, addDeptAgent, isHeadSession, removeDeptAgent } from '$lib/server/database';
+import {
+    AddDeptAgentResult,
+    addDeptAgent,
+    isHeadSession,
+    removeDeptAgent,
+} from '$lib/server/database';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';

--- a/src/routes/api/agent/+server.ts
+++ b/src/routes/api/agent/+server.ts
@@ -1,4 +1,4 @@
-import { AddDeptAgentResult, addDeptAgent, isHeadSession } from '$lib/server/database';
+import { AddDeptAgentResult, addDeptAgent, isHeadSession, removeDeptAgent } from '$lib/server/database';
 import { AssertionError } from 'node:assert/strict';
 import type { RequestHandler } from './$types';
 import { StatusCodes } from 'http-status-codes';
@@ -47,5 +47,37 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
     }
 
     const status = resultToCode(await addDeptAgent(did, uid));
+    return new Response(null, { status });
+};
+
+// eslint-disable-next-line func-style
+export const DELETE: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const rawDid = form.get('did');
+    if (rawDid === null || rawDid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const did = parseInt(rawDid, 10);
+
+    const uid = form.get('uid');
+    if (uid === null || uid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    // TODO: session has expired so we must inform the client that they should log in again
+    const head = await isHeadSession(sid, did);
+    switch (head) {
+        case null:
+            throw error(StatusCodes.UNAUTHORIZED);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+        default:
+            throw new AssertionError();
+    }
+
+    const success = await removeDeptAgent(did, uid);
+    const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;
     return new Response(null, { status });
 };


### PR DESCRIPTION
This PR introduces the `DELETE /api/agent` endpoint that removes a specified agent from the specified department.

> NOTE: (as far as I know) The DELETE statement does not throw an error when one of the input values is non-existent in the table but simply returns that it has affected zero rows, thus making the current way of checking for incorrect `dept_id` or `user_id` values inapplicable to this situation.