### PR TITLE
feat(api): implement ticket label assignment

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -283,6 +283,15 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
+CREATE FUNCTION assign_label (
+    tid ticket_labels.ticket_id %
+    TYPE,
+    lid ticket_labels.label_id %
+    TYPE
+) RETURNS VOID AS $$
+    INSERT INTO ticket_labels (ticket_id, label_id) VALUES (tid, lid);
+$$ LANGUAGE SQL;
+
 CREATE FUNCTION create_ticket (
     title tickets.title %
     TYPE,

--- a/db/init.sql
+++ b/db/init.sql
@@ -224,7 +224,7 @@ CREATE FUNCTION add_dept_agent (
     uid dept_agents.user_id %
     TYPE
 ) RETURNS VOID AS $$
-    INSERT INTO dept_agents (dept_id, user_id) VALUES (did, uid) ON CONFLICT (dept_id, user_id) DO NOTHING;
+    INSERT INTO dept_agents (dept_id, user_id) VALUES (did, uid);
 $$ LANGUAGE SQL;
 
 CREATE FUNCTION remove_dept_agent (

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -5,7 +5,13 @@ import {
     InvalidSession,
     UnexpectedStatusCode,
 } from './error';
-import { CreateTicketSchema, type Message, MessageSchema, type Ticket } from '$lib/model/ticket';
+import {
+    CreateTicketSchema,
+    type Message,
+    MessageSchema,
+    type Ticket,
+    type TicketLabel,
+} from '$lib/model/ticket';
 import type { Label } from '$lib/model/label';
 import { StatusCodes } from 'http-status-codes';
 
@@ -116,5 +122,34 @@ export async function reply(ticket: Message['ticket_id'], body: Message['body'])
             throw new InvalidSession();
         default:
             throw new UnexpectedStatusCode(res.status);
+    }
+}
+
+/**
+ * Assigns a {@linkcode Label} to a {@linkcode Ticket}. Returns `true` if successful. If the label
+ * has previously been assigned to the same ticket, it returns `false`. Otherwise, if the ticket
+ * or the label do not exist, it returns `null`.
+ */
+export async function assignLabel(ticket: TicketLabel['ticket_id'], lid: TicketLabel['label_id']) {
+    const { status } = await fetch('/api/ticket/label', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ ticket, label: lid.toString(10) }),
+    });
+    switch (status) {
+        case StatusCodes.CREATED:
+            return true;
+        case StatusCodes.CONFLICT:
+            return false;
+        case StatusCodes.NOT_FOUND:
+            return null;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
     }
 }

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -89,6 +89,9 @@ it('should complete a full user journey', async () => {
     }
 
     const nonExistentTicket = randomUUID();
+    const coolLabel = await db.createLabel('Cool', 0xc0debeef);
+    expect(coolLabel).not.toStrictEqual(0);
+
     {
         // Valid user with no labels
         const result = await db.createTicket('No Labels', uid, 'oof', []);
@@ -102,9 +105,32 @@ it('should complete a full user journey', async () => {
         expect(await db.isTicketAuthor(nonExistentTicket, uid)).toBeNull();
         expect(await db.isTicketAuthor(tid, nonExistentUser)).toStrictEqual(false);
         expect(await db.isTicketAuthor(tid, uid)).toStrictEqual(true);
-    }
 
-    const coolLabel = await db.createLabel('Cool', 0xc0debeef);
+        {
+            const assignment = await db.assignTicketLabel(nonExistentTicket, 0);
+            expect(assignment).toStrictEqual(db.AssignTicketLabelResult.NoTicket);
+        }
+
+        {
+            const assignment = await db.assignTicketLabel(nonExistentTicket, coolLabel);
+            expect(assignment).toStrictEqual(db.AssignTicketLabelResult.NoTicket);
+        }
+
+        {
+            const assignment = await db.assignTicketLabel(tid, 0);
+            expect(assignment).toStrictEqual(db.AssignTicketLabelResult.NoLabel);
+        }
+
+        {
+            const assignment = await db.assignTicketLabel(tid, coolLabel);
+            expect(assignment).toStrictEqual(db.AssignTicketLabelResult.Success);
+        }
+
+        {
+            const assignment = await db.assignTicketLabel(tid, coolLabel);
+            expect(assignment).toStrictEqual(db.AssignTicketLabelResult.AlreadyExists);
+        }
+    }
 
     {
         // Invalid user with one label

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -51,21 +51,23 @@ it('should complete a full user journey', async () => {
     expect(await db.isAdminSession(session_id)).toStrictEqual(false);
 
     const did = await db.createDept('Full User Journey');
-    expect(await db.isHeadSession(randomUUID(), 0)).toBeNull();
-    expect(await db.isHeadSession(randomUUID(), did)).toBeNull();
+    const nonExistentUser = randomUUID();
+    expect(await db.isHeadSession(nonExistentUser, 0)).toBeNull();
+    expect(await db.isHeadSession(nonExistentUser, did)).toBeNull();
     expect(await db.isHeadSession(session_id, 0)).toBeNull();
     expect(await db.isHeadSession(session_id, did)).toBeNull();
 
-    const nonExistentUser = randomUUID();
     expect(await db.addDeptAgent(0, nonExistentUser)).toStrictEqual(db.AddDeptAgentResult.NoDept);
     expect(await db.addDeptAgent(did, nonExistentUser)).toStrictEqual(db.AddDeptAgentResult.NoUser);
     expect(await db.addDeptAgent(0, uid)).toStrictEqual(db.AddDeptAgentResult.NoDept);
     expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.Success);
+    expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.AlreadyExists);
 
     expect(await db.removeDeptAgent(0, nonExistentUser)).toBeNull();
     expect(await db.removeDeptAgent(did, nonExistentUser)).toBeNull();
     expect(await db.removeDeptAgent(0, uid)).toBeNull();
     expect(await db.removeDeptAgent(did, uid)).toStrictEqual(false);
+    // TODO: add test case when the agent is actually the department head
     expect(await db.addDeptAgent(did, uid)).toStrictEqual(db.AddDeptAgentResult.Success);
 
     expect(await db.isHeadSession(session_id, did)).toStrictEqual(false);

--- a/src/routes/api/ticket/label/+server.ts
+++ b/src/routes/api/ticket/label/+server.ts
@@ -1,0 +1,49 @@
+import {
+    AssignTicketLabelResult,
+    assignTicketLabel,
+    getUserFromSession,
+    isAssignedAgent,
+} from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
+
+function resultToCode(result: AssignTicketLabelResult) {
+    switch (result) {
+        case AssignTicketLabelResult.Success:
+            return StatusCodes.CREATED;
+        case AssignTicketLabelResult.AlreadyExists:
+            return StatusCodes.CONFLICT;
+        case AssignTicketLabelResult.NoTicket:
+        case AssignTicketLabelResult.NoLabel:
+            return StatusCodes.NOT_FOUND;
+        default:
+            throw new AssertionError();
+    }
+}
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const tid = form.get('ticket');
+    if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const label = form.get('label');
+    if (label === null || label instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const lid = parseInt(label, 10) >> 0;
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+
+    const result = await isAssignedAgent(tid, user.user_id);
+    // TODO: add warning to the console if null
+    if (!result) throw error(StatusCodes.FORBIDDEN);
+
+    const status = resultToCode(await assignTicketLabel(tid, lid));
+    return new Response(null, { status });
+};


### PR DESCRIPTION
This PR implements `POST /api/ticket/label`, which assigns a label to a ticket one by one. It requires that the user is an assigned agent to the ticket.

Moreover, this PR also fixes a bug with `POST /api/agent`, which doesn't actually return the `Exists` variant prior to my changes.