### PR TITLE
feat(api): implement assignment of priority to a ticket

### DIFF
--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -67,6 +67,7 @@ export async function editTitle(id: Ticket['ticket_id'], title: Ticket['title'])
             throw new UnexpectedStatusCode(status);
     }
 }
+
 /** Assigns the `priority_id` field of a {@linkcode Ticket} to set ticket priority. Returns `false` if not found. */
 export async function assignPriority(id: Ticket['ticket_id'], priority_id: Ticket['priority_id']) {
     const { status } = await fetch('/api/ticket/priority', {

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -68,14 +68,17 @@ export async function editTitle(id: Ticket['ticket_id'], title: Ticket['title'])
     }
 }
 
-/** Assigns the `priority_id` field of a {@linkcode Ticket} to set ticket priority. Returns `false` if not found. */
-export async function assignPriority(id: Ticket['ticket_id'], priority_id: Ticket['priority_id']) {
+/**
+ * Assigns the `priority_id` field of a {@linkcode Ticket} to set ticket priority.
+ * Returns `true` if successful. Otherwise, it is `false`.
+ */
+export async function assignPriority(tid: Ticket['ticket_id'], pid: Ticket['priority_id']) {
     const { status } = await fetch('/api/ticket/priority', {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({
-            id,
-            pid: priority_id.toString(10),
+            ticket: tid,
+            priority: pid.toString(10),
         }),
     });
     switch (status) {

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -67,6 +67,31 @@ export async function editTitle(id: Ticket['ticket_id'], title: Ticket['title'])
             throw new UnexpectedStatusCode(status);
     }
 }
+/** Assigns the `priority_id` field of a {@linkcode Ticket} to set ticket priority. Returns `false` if not found. */
+export async function assignPriority(id: Ticket['ticket_id'], priority_id: Ticket['priority_id']) {
+    const { status } = await fetch('/api/ticket/priority', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        body: new URLSearchParams({
+            id,
+            pid: priority_id.toString(10),
+        }),
+    });
+    switch (status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.NOT_FOUND:
+            return false;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
+    }
+}
 
 /**
  * Edits the `due_date` field of a {@linkcode Ticket}. Returns `true` if successful.

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -144,7 +144,7 @@ it('should complete a full user journey', async () => {
         }
 
         {
-            const result = await db.assignTicketPriority(nonExistentTicket, tid);
+            const result = await db.assignTicketPriority(nonExistentTicket, pid);
             expect(result).toStrictEqual(db.AssignTicketPriorityResult.TicketNotFound);
         }
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -133,16 +133,20 @@ it('should complete a full user journey', async () => {
         const pid = await db.createPriority(priority, 0);
         expect(pid).not.toStrictEqual(0);
 
-        const nonExistentPrio = 9696;
-        expect(await db.assignTicketPriority(tid, pid)).toStrictEqual(
-            db.AssignTicketPriorityResult.Success,
-        );
-        expect(await db.assignTicketPriority(tid, nonExistentPrio)).toStrictEqual(
-            db.AssignTicketPriorityResult.InvalidPriority,
-        );
-        expect(await db.assignTicketPriority(nonExistentTicket, pid)).toStrictEqual(
-            db.AssignTicketPriorityResult.TicketNotFound,
-        );
+        {
+            const result = await db.assignTicketPriority(tid, pid);
+            expect(result).toStrictEqual(db.AssignTicketPriorityResult.Success);
+        }
+
+        {
+            const result = await db.assignTicketPriority(tid, 0);
+            expect(result).toStrictEqual(db.AssignTicketPriorityResult.InvalidPriority);
+        }
+
+        {
+            const result = await db.assignTicketPriority(nonExistentTicket, tid);
+            expect(result).toStrictEqual(db.AssignTicketPriorityResult.TicketNotFound);
+        }
 
         {
             const result = await db.editTicketDueDate(nonExistentTicket, new Date());

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -140,12 +140,12 @@ it('should complete a full user journey', async () => {
 
         {
             const result = await db.assignTicketPriority(tid, 0);
-            expect(result).toStrictEqual(db.AssignTicketPriorityResult.InvalidPriority);
+            expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoPriority);
         }
 
         {
             const result = await db.assignTicketPriority(nonExistentTicket, pid);
-            expect(result).toStrictEqual(db.AssignTicketPriorityResult.TicketNotFound);
+            expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoTicket);
         }
 
         {

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -126,26 +126,33 @@ it('should complete a full user journey', async () => {
         // TODO: add test case when the agent actually does have permission
         expect(await db.editTicketTitle(tid, 'New Title')).toStrictEqual(true);
 
-        // Creates a priority, then assigned agent sets ticket priority
-        const bytes = getRandomValues(new Uint8Array(21));
-        // TODO: add test case that checks if an agent is assigned to the ticket
-        const priority = Buffer.from(bytes).toString('base64');
-        const pid = await db.createPriority(priority, 0);
-        expect(pid).not.toStrictEqual(0);
-
         {
-            const result = await db.assignTicketPriority(tid, pid);
-            expect(result).toStrictEqual(db.AssignTicketPriorityResult.Success);
-        }
+            // Creates a priority, then assigned agent sets ticket priority
+            const bytes = getRandomValues(new Uint8Array(21));
+            // TODO: add test case that checks if an agent is assigned to the ticket
+            const priority = Buffer.from(bytes).toString('base64');
+            const pid = await db.createPriority(priority, 0);
+            expect(pid).not.toStrictEqual(0);
 
-        {
-            const result = await db.assignTicketPriority(tid, 0);
-            expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoPriority);
-        }
+            {
+                const result = await db.assignTicketPriority(nonExistentTicket, 0);
+                expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoTicket);
+            }
 
-        {
-            const result = await db.assignTicketPriority(nonExistentTicket, pid);
-            expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoTicket);
+            {
+                const result = await db.assignTicketPriority(nonExistentTicket, pid);
+                expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoTicket);
+            }
+
+            {
+                const result = await db.assignTicketPriority(tid, 0);
+                expect(result).toStrictEqual(db.AssignTicketPriorityResult.NoPriority);
+            }
+
+            {
+                const result = await db.assignTicketPriority(tid, pid);
+                expect(result).toStrictEqual(db.AssignTicketPriorityResult.Success);
+            }
         }
 
         {

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -126,6 +126,24 @@ it('should complete a full user journey', async () => {
         // TODO: add test case when the agent actually does have permission
         expect(await db.editTicketTitle(tid, 'New Title')).toStrictEqual(true);
 
+        // Creates a priority, then assigned agent sets ticket priority
+        const bytes = getRandomValues(new Uint8Array(21));
+        // TODO: add test case that checks if an agent is assigned to the ticket
+        const priority = Buffer.from(bytes).toString('base64');
+        const pid = await db.createPriority(priority, 0);
+        expect(pid).not.toStrictEqual(0);
+
+        const nonExistentPrio = 9696;
+        expect(await db.assignTicketPriority(tid, pid)).toStrictEqual(
+            db.AssignTicketPriorityResult.Success,
+        );
+        expect(await db.assignTicketPriority(tid, nonExistentPrio)).toStrictEqual(
+            db.AssignTicketPriorityResult.InvalidPriority,
+        );
+        expect(await db.assignTicketPriority(nonExistentTicket, pid)).toStrictEqual(
+            db.AssignTicketPriorityResult.TicketNotFound,
+        );
+
         {
             const result = await db.editTicketDueDate(nonExistentTicket, new Date());
             expect(result).toBeNull();

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -494,9 +494,9 @@ export const enum AssignTicketPriorityResult {
     /** Ticket priority successfully assigned. */
     Success,
     /** Ticket does not exist. */
-    TicketNotFound,
+    NoTicket,
     /** Provided priority id does not exist. */
-    InvalidPriority,
+    NoPriority,
 }
 
 /** Assigns `priority_id` field of a {@linkcode Ticket}. Returns the {@linkcode AssignTicketPriorityResult} for the operation. */
@@ -506,7 +506,7 @@ export async function assignTicketPriority(tid: Ticket['ticket_id'], pid: Ticket
             await sql`UPDATE tickets SET priority_id = ${pid} WHERE ticket_id = ${tid}`.execute();
         switch (count) {
             case 0:
-                return AssignTicketPriorityResult.TicketNotFound;
+                return AssignTicketPriorityResult.NoTicket;
             case 1:
                 return AssignTicketPriorityResult.Success;
             default:
@@ -522,7 +522,7 @@ export async function assignTicketPriority(tid: Ticket['ticket_id'], pid: Ticket
 
         switch (constraint_name) {
             case 'tickets_priority_id_fkey':
-                return AssignTicketPriorityResult.InvalidPriority;
+                return AssignTicketPriorityResult.NoPriority;
             default:
                 assert(constraint_name);
                 throw new UnexpectedConstraintName(constraint_name);

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -519,14 +519,8 @@ export async function assignTicketPriority(tid: Ticket['ticket_id'], pid: Ticket
         const { code, table_name, constraint_name } = err;
         strictEqual(code, '23503');
         strictEqual(table_name, 'tickets');
-
-        switch (constraint_name) {
-            case 'tickets_priority_id_fkey':
-                return AssignTicketPriorityResult.NoPriority;
-            default:
-                assert(constraint_name);
-                throw new UnexpectedConstraintName(constraint_name);
-        }
+        strictEqual(constraint_name, 'tickets_priority_id_fkey');
+        return AssignTicketPriorityResult.NoPriority;
     }
 }
 

--- a/src/routes/api/ticket/priority/+server.ts
+++ b/src/routes/api/ticket/priority/+server.ts
@@ -1,0 +1,44 @@
+import {
+    AssignTicketPriorityResult,
+    assignTicketPriority,
+    getUserFromSession,
+    isAssignedAgent,
+} from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from '../$types';
+import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
+
+function resultToCode(result: AssignTicketPriorityResult) {
+    switch (result) {
+        case AssignTicketPriorityResult.Success:
+            return StatusCodes.NO_CONTENT;
+        case AssignTicketPriorityResult.TicketNotFound:
+        case AssignTicketPriorityResult.InvalidPriority:
+            return StatusCodes.NOT_FOUND;
+        default:
+            throw new AssertionError();
+    }
+}
+
+// eslint-disable-next-line func-style
+export const PATCH: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const tid = form.get('id');
+    if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const priority = form.get('priority');
+    if (priority === null || priority instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const pid = parseInt(priority, 10);
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+    if (!(await isAssignedAgent(tid, user.user_id))) throw error(StatusCodes.FORBIDDEN);
+
+    const status = resultToCode(await assignTicketPriority(tid, pid));
+    return new Response(null, { status });
+};

--- a/src/routes/api/ticket/priority/+server.ts
+++ b/src/routes/api/ticket/priority/+server.ts
@@ -25,7 +25,7 @@ function resultToCode(result: AssignTicketPriorityResult) {
 export const PATCH: RequestHandler = async ({ cookies, request }) => {
     const form = await request.formData();
 
-    const tid = form.get('id');
+    const tid = form.get('ticket');
     if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
 
     const priority = form.get('priority');

--- a/src/routes/api/ticket/priority/+server.ts
+++ b/src/routes/api/ticket/priority/+server.ts
@@ -13,8 +13,8 @@ function resultToCode(result: AssignTicketPriorityResult) {
     switch (result) {
         case AssignTicketPriorityResult.Success:
             return StatusCodes.NO_CONTENT;
-        case AssignTicketPriorityResult.TicketNotFound:
-        case AssignTicketPriorityResult.InvalidPriority:
+        case AssignTicketPriorityResult.NoTicket:
+        case AssignTicketPriorityResult.NoPriority:
             return StatusCodes.NOT_FOUND;
         default:
             throw new AssertionError();


### PR DESCRIPTION
This PR implements the assignment of the priority of a ticket via the `priority_id` field, done by an assigned agent.

Also introduces `AssignTicketPriorityResult` for handling cases where the provided priority does not exist.