### PR TITLE
feat(api): implement ticket status changing

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -342,3 +342,14 @@ CREATE FUNCTION get_assigned_agents (
 TYPE AS $$
     SELECT user_id FROM assignments WHERE ticket_id = tid;
 $$ LANGUAGE SQL;
+
+CREATE FUNCTION set_status_for_ticket (
+    tid tickets.ticket_id %
+    TYPE,
+    VALUE tickets.open %
+    TYPE
+) RETURNS tickets.open %
+TYPE AS $$
+    WITH _ AS (SELECT open FROM tickets WHERE ticket_id = tid)
+        UPDATE tickets SET open = value FROM _ WHERE ticket_id = tid RETURNING _.open;
+$$ LANGUAGE SQL;

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -187,12 +187,12 @@ export async function assignLabel(ticket: TicketLabel['ticket_id'], lid: TicketL
  * Changes the status of a {@linkcode Ticket}. Returns the previous value of `open`
  * or `null` if the ticket does not exist.
  */
-export async function setStatus(tid: Ticket['ticket_id'], open: Ticket['open']) {
-    const { status } = await fetch('/api/agent/head', {
+export async function setStatus(id: Ticket['ticket_id'], open: Ticket['open']) {
+    const { status } = await fetch('/api/ticket/status', {
         method: 'PATCH',
         credentials: 'same-origin',
         body: new URLSearchParams({
-            tid,
+            id,
             open: Number(open).toString(10),
         }),
     });

--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -182,3 +182,34 @@ export async function assignLabel(ticket: TicketLabel['ticket_id'], lid: TicketL
             throw new UnexpectedStatusCode(status);
     }
 }
+
+/**
+ * Changes the status of a {@linkcode Ticket}. Returns the previous value of `open`
+ * or `null` if the ticket does not exist.
+ */
+export async function setStatus(tid: Ticket['ticket_id'], open: Ticket['open']) {
+    const { status } = await fetch('/api/agent/head', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        body: new URLSearchParams({
+            tid,
+            open: Number(open).toString(10),
+        }),
+    });
+    switch (status) {
+        case StatusCodes.NO_CONTENT:
+            return true;
+        case StatusCodes.RESET_CONTENT:
+            return false;
+        case StatusCodes.NOT_FOUND:
+            return null;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
+    }
+}

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -267,7 +267,12 @@ it('should complete a full user journey', async () => {
 
     expect(await db.setStatusForTicket(nonExistentTicket, false)).toBeNull();
     expect(await db.setStatusForTicket(tid, false)).toStrictEqual(true);
-    expect(await db.createReply(tid, uid, 'This ticket closed, fool!')).toBeNull();
+
+    {
+        const result = await db.createReply(tid, uid, 'This ticket closed, fool!');
+        expect(result).toStrictEqual(db.CreateReplyResult.Closed);
+    }
+
     expect(await db.setStatusForTicket(tid, true)).toStrictEqual(false);
 });
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -147,10 +147,10 @@ it('should complete a full user journey', async () => {
         expect(mid).not.toStrictEqual(0);
         expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
-        expect(await db.canEditTicketTitle(nonExistentTicket, nonExistentUser)).toBeNull();
-        expect(await db.canEditTicketTitle(nonExistentTicket, uid)).toBeNull();
-        expect(await db.canEditTicketTitle(tid, nonExistentUser)).toStrictEqual(false);
-        expect(await db.canEditTicketTitle(tid, uid)).toStrictEqual(true);
+        expect(await db.canEditTicket(nonExistentTicket, nonExistentUser)).toBeNull();
+        expect(await db.canEditTicket(nonExistentTicket, uid)).toBeNull();
+        expect(await db.canEditTicket(tid, nonExistentUser)).toStrictEqual(false);
+        expect(await db.canEditTicket(tid, uid)).toStrictEqual(true);
         // TODO: add test case when the agent actually does have permission
         expect(await db.editTicketTitle(tid, 'New Title')).toStrictEqual(true);
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -261,11 +261,14 @@ it('should complete a full user journey', async () => {
         expect(result).toStrictEqual(db.CreateReplyResult.NoTicket);
     }
 
-    // TODO: Add test for attempting to reply to a closed ticket
-
     const replyId = await db.createReply(tid, uid, 'Valid Reply');
     assert(typeof replyId === 'number');
     expect(replyId).not.toStrictEqual(0);
+
+    expect(await db.setStatusForTicket(nonExistentTicket, false)).toBeNull();
+    expect(await db.setStatusForTicket(tid, false)).toStrictEqual(true);
+    expect(await db.createReply(tid, uid, 'This ticket closed, fool!')).toBeNull();
+    expect(await db.setStatusForTicket(tid, true)).toStrictEqual(false);
 });
 
 it('should reject promoting non-existent users', async () => {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -582,10 +582,12 @@ export async function setStatusForTicket(tid: Ticket['ticket_id'], open: Ticket[
 }
 
 export const enum CreateReplyResult {
+    /** The ticket has already been closed. */
+    Closed = '0',
     /** The provided {@linkcode Ticket} does not exist. */
-    NoTicket = '0',
+    NoTicket = '1',
     /** The provided {@linkcode User} does not exist. */
-    NoUser = '1',
+    NoUser = '2',
 }
 
 export async function createReply(
@@ -598,7 +600,7 @@ export async function createReply(
             await sql`SELECT * FROM create_reply(${tid}, ${author}, ${body}) AS message_id WHERE message_id IS NOT NULL`.execute();
         strictEqual(rest.length, 0);
         return typeof first === 'undefined'
-            ? null
+            ? CreateReplyResult.Closed
             : MessageSchema.pick({ message_id: true }).parse(first).message_id;
     } catch (err) {
         const isExpected = err instanceof pg.PostgresError;

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -5,6 +5,7 @@ import {
     MessageSchema,
     type Ticket,
     type TicketLabel,
+    TicketSchema,
 } from '$lib/model/ticket';
 import { type Dept, type DeptLabel, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
@@ -569,6 +570,15 @@ export async function assignTicketPriority(tid: Ticket['ticket_id'], pid: Ticket
         strictEqual(constraint_name, 'tickets_priority_id_fkey');
         return AssignTicketPriorityResult.NoPriority;
     }
+}
+
+export async function setStatusForTicket(tid: Ticket['ticket_id'], open: Ticket['open']) {
+    const [first, ...rest] =
+        await sql`SELECT * FROM set_status_for_ticket(${tid}, ${open}) AS open WHERE open IS NOT NULL`.execute();
+    strictEqual(rest.length, 0);
+    return typeof first === 'undefined'
+        ? null
+        : TicketSchema.pick({ open: true }).parse(first).open;
 }
 
 export const enum CreateReplyResult {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -486,7 +486,7 @@ export async function isAssignedAgent(tid: Ticket['ticket_id'], uid: Agent['user
     return NullableBooleanResult.parse(first).result;
 }
 
-export async function canEditTicketTitle(tid: Ticket['ticket_id'], uid: User['user_id']) {
+export async function canEditTicket(tid: Ticket['ticket_id'], uid: User['user_id']) {
     const [first, ...rest] =
         await sql`SELECT get_ticket_author(${tid}) = ${uid} OR ${uid} IN (SELECT * FROM get_assigned_agents(${tid})) AS result`.execute();
     strictEqual(rest.length, 0);

--- a/src/routes/api/ticket/status/+server.ts
+++ b/src/routes/api/ticket/status/+server.ts
@@ -1,4 +1,4 @@
-import { canEditTicketTitle, getUserFromSession, setStatusForTicket } from '$lib/server/database';
+import { canEditTicket, getUserFromSession, setStatusForTicket } from '$lib/server/database';
 import type { RequestHandler } from '../$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -20,11 +20,11 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
     const user = await getUserFromSession(sid);
     if (user === null) throw error(StatusCodes.UNAUTHORIZED);
     // Permissions are the same as canEditTicketTitle: ticket author and assigned agents
-    if (!(await canEditTicketTitle(tid, user.user_id))) throw error(StatusCodes.FORBIDDEN);
+    if (!(await canEditTicket(tid, user.user_id))) throw error(StatusCodes.FORBIDDEN);
 
     const prev = await setStatusForTicket(tid, open);
     if (prev === null) return new Response(null, { status: StatusCodes.NOT_FOUND });
 
-    const status = prev ? StatusCodes.NO_CONTENT : StatusCodes.RESET_CONTENT;
+    const status = prev === open ? StatusCodes.RESET_CONTENT : StatusCodes.NO_CONTENT;
     return new Response(null, { status });
 };

--- a/src/routes/api/ticket/status/+server.ts
+++ b/src/routes/api/ticket/status/+server.ts
@@ -1,0 +1,30 @@
+import { canEditTicketTitle, getUserFromSession, setStatusForTicket } from '$lib/server/database';
+import type { RequestHandler } from '../$types';
+import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
+
+// eslint-disable-next-line func-style
+export const PATCH: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const tid = form.get('id');
+    if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const rawOpen = form.get('open');
+    if (rawOpen === null || rawOpen instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const open = Boolean(parseInt(rawOpen, 10));
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+    // Permissions are the same as canEditTicketTitle: ticket author and assigned agents
+    if (!(await canEditTicketTitle(tid, user.user_id))) throw error(StatusCodes.FORBIDDEN);
+
+    const prev = await setStatusForTicket(tid, open);
+    if (prev === null) return new Response(null, { status: StatusCodes.NOT_FOUND });
+
+    const status = prev ? StatusCodes.NO_CONTENT : StatusCodes.RESET_CONTENT;
+    return new Response(null, { status });
+};

--- a/src/routes/api/ticket/title/+server.ts
+++ b/src/routes/api/ticket/title/+server.ts
@@ -1,4 +1,4 @@
-import { canEditTicketTitle, editTicketTitle, getUserFromSession } from '$lib/server/database';
+import { canEditTicket, editTicketTitle, getUserFromSession } from '$lib/server/database';
 import type { RequestHandler } from '../$types';
 import { StatusCodes } from 'http-status-codes';
 import { error } from '@sveltejs/kit';
@@ -18,7 +18,7 @@ export const PATCH: RequestHandler = async ({ cookies, request }) => {
 
     const user = await getUserFromSession(sid);
     if (user === null) throw error(StatusCodes.UNAUTHORIZED);
-    if (!(await canEditTicketTitle(tid, user.user_id))) throw error(StatusCodes.FORBIDDEN);
+    if (!(await canEditTicket(tid, user.user_id))) throw error(StatusCodes.FORBIDDEN);
 
     const success = await editTicketTitle(tid, title);
     const status = success ? StatusCodes.NO_CONTENT : StatusCodes.NOT_FOUND;


### PR DESCRIPTION
This PR introduces an endpoint `PATCH /api/ticket/status` which allows the ticket author or assigned agents to edit the status of ticket from Open to Closed/Resolved or vice-versa. The endpoint returns the previous status of the ticket.