### PR TITLE
feat (api): Implemented getters

### DIFF
--- a/db/funcs.sql
+++ b/db/funcs.sql
@@ -248,19 +248,19 @@ $$ LANGUAGE SQL;
 
 CREATE OR
 REPLACE FUNCTION get_agents_by_dept (
-    did depts.dept_id %
+    did dept_agents.dept_id %
     TYPE
-) RETURNS dept_agents AS $$
-    SELECT *  FROM dept_agents WHERE dept_id = did;
+) RETURNS SETOF dept_agents.user_id %
+TYPE AS $$
+    SELECT user_id FROM dept_agents WHERE dept_id = did;
 $$ LANGUAGE SQL;
 
 CREATE OR
 REPLACE FUNCTION get_users_outside_dept (
     did depts.dept_id %
     TYPE
-) RETURNS users AS $$
-    SELECT * FROM users EXCEPT 
-    SELECT * FROM users WHERE user_id IN (SELECT user_id FROM get_agents_by_dept(did));
+) RETURNS SETOF users AS $$
+    SELECT * FROM users WHERE user_id NOT IN (SELECT * FROM get_agents_by_dept(did));
 $$ LANGUAGE SQL;
 
 CREATE OR

--- a/db/funcs.sql
+++ b/db/funcs.sql
@@ -247,6 +247,23 @@ TYPE AS $$
 $$ LANGUAGE SQL;
 
 CREATE OR
+REPLACE FUNCTION get_agents_by_dept (
+    did depts.dept_id %
+    TYPE
+) RETURNS dept_agents AS $$
+    SELECT *  FROM dept_agents WHERE dept_id = did;
+$$ LANGUAGE SQL;
+
+CREATE OR
+REPLACE FUNCTION get_users_outside_dept (
+    did depts.dept_id %
+    TYPE
+) RETURNS users AS $$
+    SELECT * FROM users EXCEPT 
+    SELECT * FROM users WHERE user_id IN (SELECT user_id FROM get_agents_by_dept(did));
+$$ LANGUAGE SQL;
+
+CREATE OR
 REPLACE FUNCTION set_status_for_ticket (
     tid tickets.ticket_id %
     TYPE,

--- a/src/lib/model/label.ts
+++ b/src/lib/model/label.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const LabelSchema = z.object({
     label_id: z.number().int().positive(),
     title: z.string().max(32),
-    color: z.number().int(),
+    color: z
+        .number()
+        .int()
+        .transform(hex => hex >>> 0),
     deadline: z.number().int().positive().nullable(),
 });
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -293,7 +293,7 @@ it('should complete a full user journey', async () => {
     }
 
     {
-        const { length } = await db.getAgentByDept(1);
+        const { length } = await db.getAgentIdsByDept(1);
         expect(length).toBeGreaterThan(0);
     }
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -5,9 +5,10 @@ import {
     MessageSchema,
     type Ticket,
     type TicketLabel,
+    TicketLabelSchema,
     TicketSchema,
 } from '$lib/model/ticket';
-import { type Dept, type DeptLabel, DeptSchema } from '$lib/model/dept';
+import { type Dept, type DeptLabel, DeptLabelSchema, DeptSchema } from '$lib/model/dept';
 import { type Label, LabelSchema } from '$lib/model/label';
 import { type Pending, PendingSchema, type Session } from '$lib/server/model/session';
 import { type Priority, PrioritySchema } from '$lib/model/priority';
@@ -570,6 +571,68 @@ export async function assignTicketPriority(tid: Ticket['ticket_id'], pid: Ticket
         strictEqual(constraint_name, 'tickets_priority_id_fkey');
         return AssignTicketPriorityResult.NoPriority;
     }
+}
+
+export async function getAgents() {
+    const rows = await sql`SELECT * FROM dept_agents`.execute();
+    return AgentSchema.array().parse(rows);
+}
+
+export async function getAgentByDept(did: Dept['dept_id']) {
+    const rows = await sql`SELECT * FROM get_agents_by_dept(${did})`.execute();
+    return AgentSchema.array().parse(rows);
+}
+
+export async function getDepartments() {
+    const rows = await sql`SELECT * FROM depts`.execute();
+    return DeptSchema.array().parse(rows);
+}
+
+export async function getDeptLabels() {
+    const rows = await sql`SELECT * FROM dept_labels`.execute();
+    return DeptLabelSchema.array().parse(rows);
+}
+
+export async function getLabels() {
+    const rows = await sql`SELECT label_id, title, color, 
+        CASE WHEN deadline IS NOT NULL THEN CAST(EXTRACT(days FROM deadline) AS INT)
+        END deadline FROM labels`.execute();
+    return LabelSchema.array().parse(rows);
+}
+
+export async function getMessages() {
+    const rows = await sql`SELECT * FROM messages`.execute();
+    return MessageSchema.array().parse(rows);
+}
+
+export async function getPendings() {
+    const rows = await sql`SELECT * FROM pendings`.execute();
+    return PendingSchema.array().parse(rows);
+}
+
+export async function getPriorities() {
+    const rows = await sql`SELECT * FROM priorities`.execute();
+    return PrioritySchema.array().parse(rows);
+}
+
+export async function getTickets() {
+    const rows = await sql`SELECT * FROM tickets`.execute();
+    return TicketSchema.array().parse(rows);
+}
+
+export async function getTicketLabels() {
+    const rows = await sql`SELECT * FROM ticket_labels`.execute();
+    return TicketLabelSchema.array().parse(rows);
+}
+
+export async function getUsers() {
+    const rows = await sql`SELECT * FROM users`.execute();
+    return UserSchema.array().parse(rows);
+}
+
+export async function getUsersOutsideDept(did: Dept['dept_id']) {
+    const rows = await sql`SELECT * FROM get_users_outside_dept(${did})`.execute();
+    return UserSchema.array().parse(rows);
 }
 
 export async function setStatusForTicket(tid: Ticket['ticket_id'], open: Ticket['open']) {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -573,14 +573,12 @@ export async function assignTicketPriority(tid: Ticket['ticket_id'], pid: Ticket
     }
 }
 
-export async function getAgents() {
-    const rows = await sql`SELECT * FROM dept_agents`.execute();
-    return AgentSchema.array().parse(rows);
-}
-
-export async function getAgentByDept(did: Dept['dept_id']) {
-    const rows = await sql`SELECT * FROM get_agents_by_dept(${did})`.execute();
-    return AgentSchema.array().parse(rows);
+export async function getAgentIdsByDept(did: Dept['dept_id']) {
+    const rows = await sql`SELECT get_agents_by_dept(${did}) AS user_id`.execute();
+    return AgentSchema.pick({ user_id: true })
+        .array()
+        .parse(rows)
+        .map(agent => agent.user_id);
 }
 
 export async function getDepartments() {
@@ -594,9 +592,8 @@ export async function getDeptLabels() {
 }
 
 export async function getLabels() {
-    const rows = await sql`SELECT label_id, title, color, 
-        CASE WHEN deadline IS NOT NULL THEN CAST(EXTRACT(days FROM deadline) AS INT)
-        END deadline FROM labels`.execute();
+    const rows =
+        await sql`SELECT label_id, title, color, EXTRACT(days FROM deadline)::INT AS deadline FROM labels`.execute();
     return LabelSchema.array().parse(rows);
 }
 


### PR DESCRIPTION
Made getters for Agents, Departments, Dept Labels, Labels, Messages, Pendings, Prioties, Tickets, Ticket Labels, and Users
Added get_agents_by_dept  and users_outside_dept to func.sql

Made generic test cases for all getters (expect to be greater than 0)