### PR TITLE
feat(api): implement agent self-assignment

### DIFF
--- a/src/lib/api/ticket.ts
+++ b/src/lib/api/ticket.ts
@@ -12,6 +12,7 @@ import {
     type Ticket,
     type TicketLabel,
 } from '$lib/model/ticket';
+import type { Agent } from '$lib/model/agent';
 import type { Label } from '$lib/model/label';
 import { StatusCodes } from 'http-status-codes';
 
@@ -203,6 +204,32 @@ export async function setStatus(id: Ticket['ticket_id'], open: Ticket['open']) {
             return false;
         case StatusCodes.NOT_FOUND:
             return null;
+        case StatusCodes.BAD_REQUEST:
+            throw new BadInput();
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        case StatusCodes.FORBIDDEN:
+            throw new InsufficientPermissions();
+        default:
+            throw new UnexpectedStatusCode(status);
+    }
+}
+
+/**
+ * Assigns self (on behalf of `dept`) to the `ticket`. If the ticket or the user cannot be found,
+ * this function returns `false`. Otherwise, it returns `true` on successful assignments.
+ */
+export async function assignSelf(ticket: Ticket['ticket_id'], dept: Agent['dept_id']) {
+    const { status } = await fetch('/api/ticket/claim', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ ticket, dept: dept.toString(10) }),
+    });
+    switch (status) {
+        case StatusCodes.CREATED:
+            return true;
+        case StatusCodes.NOT_FOUND:
+            return false;
         case StatusCodes.BAD_REQUEST:
             throw new BadInput();
         case StatusCodes.UNAUTHORIZED:

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -75,6 +75,10 @@ it('should complete a full user journey', async () => {
     expect(await db.isHeadSession(session_id, 0)).toBeNull();
     expect(await db.isHeadSession(session_id, did)).toBeNull();
 
+    const nonExistentTicket = randomUUID();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, uid)).toBeNull();
+
     expect(await db.addDeptAgent(0, nonExistentUser)).toStrictEqual(db.AddDeptAgentResult.NoDept);
     expect(await db.addDeptAgent(did, nonExistentUser)).toStrictEqual(db.AddDeptAgentResult.NoUser);
     expect(await db.addDeptAgent(0, uid)).toStrictEqual(db.AddDeptAgentResult.NoDept);
@@ -111,7 +115,6 @@ it('should complete a full user journey', async () => {
         expect(result).toStrictEqual(db.CreateTicketResult.NoLabels);
     }
 
-    const nonExistentTicket = randomUUID();
     const coolLabel = await db.createLabel('Cool', 0xc0debeef);
     expect(coolLabel).not.toStrictEqual(0);
 
@@ -279,10 +282,15 @@ it('should complete a full user journey', async () => {
     expect(mid).not.toStrictEqual(0);
     expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
-    expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toStrictEqual(null);
-    expect(await db.isTicketAuthor(nonExistentTicket, uid)).toStrictEqual(null);
+    expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toBeNull();
+    expect(await db.isTicketAuthor(nonExistentTicket, uid)).toBeNull();
     expect(await db.isTicketAuthor(tid, nonExistentUser)).toStrictEqual(false);
     expect(await db.isTicketAuthor(tid, uid)).toStrictEqual(true);
+
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, uid)).toBeNull();
+    expect(await db.canAssignSelfToTicket(tid, nonExistentUser)).toStrictEqual(false);
+    expect(await db.canAssignSelfToTicket(tid, uid)).toStrictEqual(true);
 
     {
         const result = await db.createReply(tid, nonExistentUser, 'No User');

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -338,6 +338,11 @@ it('should complete a full user journey', async () => {
     }
 
     {
+        const result = await db.assignAgentToTicket(tid, did, uid);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.Exists);
+    }
+
+    {
         const result = await db.createReply(tid, nonExistentUser, 'No User');
         expect(result).toStrictEqual(db.CreateReplyResult.NoUser);
     }

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -195,7 +195,6 @@ it('should complete a full user journey', async () => {
         {
             // Creates a priority, then assigned agent sets ticket priority
             const bytes = getRandomValues(new Uint8Array(21));
-            // TODO: add test case that checks if an agent is assigned to the ticket
             const priority = Buffer.from(bytes).toString('base64');
             const pid = await db.createPriority(priority, 0);
             expect(pid).not.toStrictEqual(0);

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -76,8 +76,10 @@ it('should complete a full user journey', async () => {
     expect(await db.isHeadSession(session_id, did)).toBeNull();
 
     const nonExistentTicket = randomUUID();
-    expect(await db.canAssignSelfToTicket(nonExistentTicket, nonExistentUser)).toBeNull();
-    expect(await db.canAssignSelfToTicket(nonExistentTicket, uid)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, 0, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, 0, uid)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, did, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, did, uid)).toBeNull();
 
     expect(await db.addDeptAgent(0, nonExistentUser)).toStrictEqual(db.AddDeptAgentResult.NoDept);
     expect(await db.addDeptAgent(did, nonExistentUser)).toStrictEqual(db.AddDeptAgentResult.NoUser);
@@ -287,10 +289,54 @@ it('should complete a full user journey', async () => {
     expect(await db.isTicketAuthor(tid, nonExistentUser)).toStrictEqual(false);
     expect(await db.isTicketAuthor(tid, uid)).toStrictEqual(true);
 
-    expect(await db.canAssignSelfToTicket(nonExistentTicket, nonExistentUser)).toBeNull();
-    expect(await db.canAssignSelfToTicket(nonExistentTicket, uid)).toBeNull();
-    expect(await db.canAssignSelfToTicket(tid, nonExistentUser)).toStrictEqual(false);
-    expect(await db.canAssignSelfToTicket(tid, uid)).toStrictEqual(true);
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, 0, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, 0, uid)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, did, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(nonExistentTicket, did, uid)).toBeNull();
+    expect(await db.canAssignSelfToTicket(tid, 0, nonExistentUser)).toBeNull();
+    expect(await db.canAssignSelfToTicket(tid, 0, uid)).toBeNull();
+    expect(await db.canAssignSelfToTicket(tid, did, nonExistentUser)).toStrictEqual(false);
+    expect(await db.canAssignSelfToTicket(tid, did, uid)).toStrictEqual(true);
+
+    {
+        const result = await db.assignAgentToTicket(nonExistentTicket, 0, nonExistentUser);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoTicket);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(nonExistentTicket, 0, uid);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoTicket);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(nonExistentTicket, did, nonExistentUser);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoTicket);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(nonExistentTicket, did, uid);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoTicket);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(tid, 0, nonExistentUser);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoAgent);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(tid, 0, uid);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoAgent);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(tid, did, nonExistentUser);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.NoAgent);
+    }
+
+    {
+        const result = await db.assignAgentToTicket(tid, did, uid);
+        expect(result).toStrictEqual(db.AssignAgentToTicketResult.Success);
+    }
 
     {
         const result = await db.createReply(tid, nonExistentUser, 'No User');

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -658,8 +658,7 @@ export async function assignAgentToTicket(
     uid: Agent['user_id'],
 ) {
     try {
-        const { count } =
-            await sql`SELECT assign_agent_to_ticket(${tid}, ${did}, ${uid})`;
+        const { count } = await sql`SELECT assign_agent_to_ticket(${tid}, ${did}, ${uid})`;
         strictEqual(count, 1);
         return AssignAgentToTicketResult.Success;
     } catch (err) {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -632,6 +632,13 @@ export async function getUsersOutsideDept(did: Dept['dept_id']) {
     return UserSchema.array().parse(rows);
 }
 
+export async function canAssignSelfToTicket(tid: Ticket['ticket_id'], uid: Agent['user_id']) {
+    const [first, ...rest] =
+        await sql`SELECT can_assign_self_to_ticket(${tid}, ${uid}) AS result`.execute();
+    strictEqual(rest.length, 0);
+    return NullableBooleanResult.parse(first).result;
+}
+
 export async function setStatusForTicket(tid: Ticket['ticket_id'], open: Ticket['open']) {
     const [first, ...rest] =
         await sql`SELECT * FROM set_status_for_ticket(${tid}, ${open}) AS open WHERE open IS NOT NULL`.execute();

--- a/src/routes/api/ticket/claim/+server.ts
+++ b/src/routes/api/ticket/claim/+server.ts
@@ -1,0 +1,54 @@
+import {
+    AssignAgentToTicketResult,
+    assignAgentToTicket,
+    canAssignSelfToTicket,
+    getUserFromSession,
+} from '$lib/server/database';
+import { AssertionError } from 'node:assert/strict';
+import type { RequestHandler } from './$types';
+import { StatusCodes } from 'http-status-codes';
+import { error } from '@sveltejs/kit';
+
+function resultToCode(result: AssignAgentToTicketResult) {
+    switch (result) {
+        case AssignAgentToTicketResult.Success:
+            return StatusCodes.CREATED;
+        case AssignAgentToTicketResult.NoTicket:
+        case AssignAgentToTicketResult.NoAgent:
+            return StatusCodes.NOT_FOUND;
+        default:
+            throw new AssertionError();
+    }
+}
+
+// eslint-disable-next-line func-style
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const form = await request.formData();
+
+    const tid = form.get('ticket');
+    if (tid === null || tid instanceof File) throw error(StatusCodes.BAD_REQUEST);
+
+    const dept = form.get('dept');
+    if (dept === null || dept instanceof File) throw error(StatusCodes.BAD_REQUEST);
+    const did = parseInt(dept, 10) >> 0;
+
+    const sid = cookies.get('sid');
+    if (!sid) throw error(StatusCodes.UNAUTHORIZED);
+
+    const user = await getUserFromSession(sid);
+    if (user === null) throw error(StatusCodes.UNAUTHORIZED);
+
+    switch (await canAssignSelfToTicket(tid, did, user.user_id)) {
+        case null:
+            throw error(StatusCodes.NOT_FOUND);
+        case false:
+            throw error(StatusCodes.FORBIDDEN);
+        case true:
+            break;
+        default:
+            throw new AssertionError();
+    }
+
+    const status = resultToCode(await assignAgentToTicket(tid, did, user.user_id));
+    return new Response(null, { status });
+};


### PR DESCRIPTION
This PR implements the ability for agents to "self-assign" or "claim" a ticket. The only requirement to invoke the endpoint `POST /api/ticket/claim` is that the agent must already be a member of the department that _is_ subscribed to a label previously assigned to that ticket.