### PR TITLE
feat: order inbox by priority => due date => creation

### DIFF
--- a/db/funcs.sql
+++ b/db/funcs.sql
@@ -296,8 +296,10 @@ REPLACE FUNCTION get_first_ticket_message (
     body messages.body %
     TYPE
 ) AS $$
-    SELECT MIN(creation) AS creation, author_id, body FROM messages
-        WHERE ticket_id = tid GROUP BY creation;
+    SELECT creation, author_id, body
+        FROM messages,
+        LATERAL (SELECT MIN(creation) AS mid FROM messages WHERE ticket_id = tid) _
+        WHERE creation = _.mid;
 $$ STABLE LANGUAGE SQL;
 
 CREATE OR

--- a/db/tables.sql
+++ b/db/tables.sql
@@ -93,15 +93,14 @@ CREATE TABLE
 
 CREATE TABLE
     messages (
+        creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         author_id GoogleUserId REFERENCES users (user_id),
         ticket_id UUID NOT NULL REFERENCES tickets (ticket_id),
-        message_id SERIAL NOT NULL,
-        creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         body VARCHAR(1024) NOT NULL,
-        PRIMARY KEY (ticket_id, message_id)
+        PRIMARY KEY (creation)
     );
 
-CREATE INDEX idx_messages_creation ON messages (creation);
+CREATE INDEX idx_messages_ticket_id ON messages (ticket_id);
 
 CREATE TABLE
     labels (

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
         "svelte-check": "^3.5.0",
         "svelte-fa": "^3.0.4",
         "tailwindcss": "^3.3.3",
-        "tslib": "^2.6.1",
+        "tslib": "^2.6.2",
         "typescript": "^5.1.6",
         "vite": "^4.4.9",
         "vitest": "^0.34.2",
-        "zod": "^3.22.1"
+        "zod": "^3.22.2"
     },
     "pnpm": {
         "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,20 +88,20 @@ devDependencies:
     specifier: ^3.3.3
     version: 3.3.3
   tslib:
-    specifier: ^2.6.1
-    version: 2.6.1
+    specifier: ^2.6.2
+    version: 2.6.2
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
   vite:
     specifier: ^4.4.9
-    version: 4.4.9(@types/node@20.5.0)
+    version: 4.4.9(@types/node@20.5.1)
   vitest:
     specifier: ^0.34.2
     version: 0.34.2
   zod:
-    specifier: ^3.22.1
-    version: 3.22.1
+    specifier: ^3.22.2
+    version: 3.22.2
 
 packages:
 
@@ -577,7 +577,7 @@ packages:
       sirv: 2.0.3
       svelte: 4.2.0
       undici: 5.23.0
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9(@types/node@20.5.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -593,7 +593,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.4.5(svelte@4.2.0)(vite@4.4.9)
       debug: 4.3.4
       svelte: 4.2.0
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9(@types/node@20.5.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -612,7 +612,7 @@ packages:
       magic-string: 0.30.2
       svelte: 4.2.0
       svelte-hmr: 0.15.3(svelte@4.2.0)
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9(@types/node@20.5.1)
       vitefu: 0.2.4(vite@4.4.9)
     transitivePeerDependencies:
       - supports-color
@@ -653,8 +653,8 @@ packages:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
     dev: true
 
-  /@types/node@20.5.0:
-    resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
+  /@types/node@20.5.1:
+    resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
 
   /@types/pug@2.0.6:
@@ -692,7 +692,7 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -741,7 +741,7 @@ packages:
       '@typescript-eslint/utils': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.47.0
-      ts-api-utils: 1.0.1(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -767,7 +767,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -926,8 +926,8 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.10
-      caniuse-lite: 1.0.30001521
-      fraction.js: 4.2.0
+      caniuse-lite: 1.0.30001522
+      fraction.js: 4.2.1
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss: 8.4.28
@@ -998,8 +998,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001521
-      electron-to-chromium: 1.4.494
+      caniuse-lite: 1.0.30001522
+      electron-to-chromium: 1.4.496
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
@@ -1035,8 +1035,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /caniuse-lite@1.0.30001521:
-    resolution: {integrity: sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==}
+  /caniuse-lite@1.0.30001522:
+    resolution: {integrity: sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==}
     dev: true
 
   /chai@4.3.7:
@@ -1218,8 +1218,8 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /electron-to-chromium@1.4.494:
-    resolution: {integrity: sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww==}
+  /electron-to-chromium@1.4.496:
+    resolution: {integrity: sha512-qeXC3Zbykq44RCrBa4kr8v/dWzYJA8rAwpyh9Qd+NKWoJfjG5vvJqy9XOJ9H4P/lqulZBCgUWAYi+FeK5AuJ8g==}
     dev: true
 
   /es6-promise@3.3.1:
@@ -1472,8 +1472,8 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
-  /fraction.js@4.2.0:
-    resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
+  /fraction.js@4.2.1:
+    resolution: {integrity: sha512-/KxoyCnPM0GwYI4NN0Iag38Tqt+od3/mLuguepLgCAKPn0ZhC544nssAW0tG2/00zXEYl9W+7hwAIpLHo6Oc7Q==}
     dev: true
 
   /fs.realpath@1.0.0:
@@ -1686,8 +1686,8 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /jiti@1.19.1:
-    resolution: {integrity: sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==}
+  /jiti@1.19.3:
+    resolution: {integrity: sha512-5eEbBDQT/jF1xg6l36P+mWGGoH9Spuy0PCdSr2dtWRDGC6ph/w9ZCL4lmESW8f8F7MwT3XKescfP0wnZWAKL9w==}
     hasBin: true
     dev: true
 
@@ -2162,7 +2162,7 @@ packages:
       node-sql-parser: 4.9.0
       prettier: 2.8.8
       sql-formatter: 12.2.4
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: true
 
   /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@4.2.0):
@@ -2422,8 +2422,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /std-env@3.3.3:
-    resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
+  /std-env@3.4.0:
+    resolution: {integrity: sha512-YqHeQIIQ8r1VtUZOTOyjsAXAsjr369SplZ5rlQaiJTBsvodvPSCME7vuz8pnQltbQ0Cw0lyFo5Q8uyNwYQ58Xw==}
     dev: true
 
   /streamsearch@1.1.0:
@@ -2619,7 +2619,7 @@ packages:
       fast-glob: 3.3.1
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.19.1
+      jiti: 1.19.3
       lilconfig: 2.1.0
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -2680,8 +2680,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /ts-api-utils@1.0.1(typescript@5.1.6):
-    resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
+  /ts-api-utils@1.0.2(typescript@5.1.6):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
@@ -2693,8 +2693,8 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tslib@2.6.1:
-    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
   /type-check@0.4.0:
@@ -2752,7 +2752,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite-node@0.34.2(@types/node@20.5.0):
+  /vite-node@0.34.2(@types/node@20.5.1):
     resolution: {integrity: sha512-JtW249Zm3FB+F7pQfH56uWSdlltCo1IOkZW5oHBzeQo0iX4jtC7o1t9aILMGd9kVekXBP2lfJBEQt9rBh07ebA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -2762,7 +2762,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9(@types/node@20.5.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -2774,7 +2774,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.9(@types/node@20.5.0):
+  /vite@4.4.9(@types/node@20.5.1):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -2802,7 +2802,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       esbuild: 0.18.20
       postcss: 8.4.28
       rollup: 3.28.0
@@ -2818,7 +2818,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9(@types/node@20.5.1)
     dev: true
 
   /vitest@0.34.2:
@@ -2854,7 +2854,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       '@vitest/expect': 0.34.2
       '@vitest/runner': 0.34.2
       '@vitest/snapshot': 0.34.2
@@ -2869,12 +2869,12 @@ packages:
       magic-string: 0.30.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      std-env: 3.3.3
+      std-env: 3.4.0
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@20.5.0)
-      vite-node: 0.34.2(@types/node@20.5.0)
+      vite: 4.4.9(@types/node@20.5.1)
+      vite-node: 0.34.2(@types/node@20.5.1)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -2931,6 +2931,6 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /zod@3.22.1:
-    resolution: {integrity: sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==}
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: true

--- a/src/lib/model/ticket.ts
+++ b/src/lib/model/ticket.ts
@@ -30,10 +30,10 @@ export const CreateTicketSchema = z.object({
 });
 
 export const OpenTicketSchema = z.object({
-    ticket_id: z.string().uuid(),
-    title: z.string().max(128),
-    due: z.coerce.date(),
-    priority: PrioritySchema.pick({ title: true, priority: true }).nullable(),
+    ticket_id: TicketSchema.shape.ticket_id,
+    ticket: TicketSchema.shape.title,
+    due: TicketSchema.shape.due_date,
+    priority: PrioritySchema.shape.title.nullable(),
 });
 
 export const TicketInfoSchema = z.object({

--- a/src/lib/model/ticket.ts
+++ b/src/lib/model/ticket.ts
@@ -17,16 +17,15 @@ export const TicketLabelSchema = z.object({
 });
 
 export const MessageSchema = z.object({
+    creation: z.coerce.date(),
     author_id: UserSchema.shape.user_id,
     ticket_id: TicketSchema.shape.ticket_id,
-    message_id: z.number().int().positive(),
-    creation: z.coerce.date(),
     body: z.string().max(1024),
 });
 
 export const CreateTicketSchema = z.object({
     tid: TicketSchema.shape.ticket_id,
-    mid: MessageSchema.shape.message_id,
+    mid: MessageSchema.shape.creation,
     due: TicketSchema.shape.due_date,
 });
 

--- a/src/lib/server/database/index.test.ts
+++ b/src/lib/server/database/index.test.ts
@@ -141,7 +141,7 @@ it('should complete a full user journey', async () => {
         assert(typeof result === 'object');
         const { tid, mid, due } = result;
         expect(tid).toHaveLength(36);
-        expect(mid).not.toStrictEqual(0);
+        expect(mid.getTime()).toBeLessThan(Date.now());
         expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
         expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toBeNull();
@@ -187,7 +187,7 @@ it('should complete a full user journey', async () => {
         assert(typeof result === 'object');
         const { tid, mid, due } = result;
         expect(tid).toHaveLength(36);
-        expect(mid).not.toStrictEqual(0);
+        expect(mid.getTime()).toBeLessThan(Date.now());
         expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
         expect(await db.canEditTicket(nonExistentTicket, nonExistentUser)).toBeNull();
@@ -286,7 +286,7 @@ it('should complete a full user journey', async () => {
     assert(typeof createTicketResult === 'object');
     const { tid, mid, due } = createTicketResult;
     expect(tid).toHaveLength(36);
-    expect(mid).not.toStrictEqual(0);
+    expect(mid.getTime()).toBeLessThan(Date.now());
     expect(due.getTime()).toBeGreaterThanOrEqual(Date.now());
 
     expect(await db.isTicketAuthor(nonExistentTicket, nonExistentUser)).toBeNull();
@@ -378,8 +378,7 @@ it('should complete a full user journey', async () => {
     expect(await db.removeTicketAgent(tid, did, nonExistentUser)).toStrictEqual(false);
 
     const replyId = await db.createReply(tid, uid, 'Valid Reply');
-    assert(typeof replyId === 'number');
-    expect(replyId).not.toStrictEqual(0);
+    assert(replyId instanceof Date);
 
     expect(await db.getTicketThread(nonExistentTicket)).toHaveLength(0);
 
@@ -391,7 +390,7 @@ it('should complete a full user journey', async () => {
             name: 'Test',
             email: `${email}@example.com`,
             picture: 'http://example.com/avatar.png',
-            message_id: mid,
+            creation: mid,
             body: 'yay!',
         });
         expect(second).toMatchObject({
@@ -399,7 +398,7 @@ it('should complete a full user journey', async () => {
             name: 'Test',
             email: `${email}@example.com`,
             picture: 'http://example.com/avatar.png',
-            message_id: replyId,
+            creation: replyId,
             body: 'Valid Reply',
         });
     }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -682,14 +682,14 @@ export async function getPriorities() {
 export async function getUserInbox(uid: User['user_id']) {
     // TODO: Add Test Cases
     const rows =
-        await sql`SELECT ticket_id, title, LEAST(due, to_timestamp(8640000000000)) AS due, priority FROM get_user_inbox(${uid})`.execute();
+        await sql`SELECT ticket_id, ticket, LEAST(due, to_timestamp(8640000000000)) AS due, priority FROM get_user_inbox(${uid})`.execute();
     return OpenTicketSchema.array().parse(rows);
 }
 
 export async function getAgentInbox(uid: User['user_id']) {
     // TODO: Add Test Cases
     const rows =
-        await sql`SELECT ticket_id, title, LEAST(due, to_timestamp(8640000000000)) AS due, priority FROM get_agent_inbox(${uid})`.execute();
+        await sql`SELECT ticket_id, ticket, LEAST(due, to_timestamp(8640000000000)) AS due, priority FROM get_agent_inbox(${uid})`.execute();
     return OpenTicketSchema.array().parse(rows);
 }
 

--- a/src/routes/dashboard/inbox/Inbox.svelte
+++ b/src/routes/dashboard/inbox/Inbox.svelte
@@ -16,15 +16,14 @@
             </tr>
         </thead>
         <tbody>
-            {#each tickets as { ticket_id, title, due, priority } (ticket_id)}
+            {#each tickets as { ticket_id, ticket, due, priority } (ticket_id)}
                 <tr>
                     <td>{ticket_id}</td>
-                    <td><a href="/dashboard/ticket/{ticket_id}" class="anchor">{title}</a></td>
+                    <td><a href="/dashboard/ticket/{ticket_id}" class="anchor">{ticket}</a></td>
                     <td>{due.toLocaleString()}</td>
                     <td>
-                        {#if priority !== null}
-                            {@const { title, priority: value } = priority}
-                            {title} [{value}]
+                        {#if priority}
+                            {priority}
                         {/if}
                     </td>
                 </tr>

--- a/src/routes/dashboard/ticket/+page.server.ts
+++ b/src/routes/dashboard/ticket/+page.server.ts
@@ -43,7 +43,8 @@ export const actions = {
         if (typeof result === 'object') {
             // TODO: Somehow log the `due` date.
             const { tid, mid } = result;
-            throw redirect(StatusCodes.MOVED_TEMPORARILY, `/dashboard/ticket/${tid}#${mid}`);
+            const hash = mid.getTime();
+            throw redirect(StatusCodes.MOVED_TEMPORARILY, `/dashboard/ticket/${tid}#${hash}`);
         }
 
         switch (result) {

--- a/src/routes/dashboard/ticket/[id]/+page.server.ts
+++ b/src/routes/dashboard/ticket/[id]/+page.server.ts
@@ -49,10 +49,10 @@ export const actions = {
         const user = await getUserFromSession(sid);
         if (user === null) throw error(StatusCodes.UNAUTHORIZED);
 
-        const mid = await createReply(id, user.user_id, body);
-        if (typeof mid === 'number') return { mid };
+        const creation = await createReply(id, user.user_id, body);
+        if (creation instanceof Date) return { mid: creation.getTime() };
 
-        const status = resultToCode(mid);
+        const status = resultToCode(creation);
         throw error(status);
     },
 } satisfies Actions;

--- a/src/routes/dashboard/ticket/[id]/+page.server.ts
+++ b/src/routes/dashboard/ticket/[id]/+page.server.ts
@@ -49,6 +49,12 @@ export const actions = {
         const user = await getUserFromSession(sid);
         if (user === null) throw error(StatusCodes.UNAUTHORIZED);
 
+        // TODO: Use microsecond- or nanosecond-precision for the `mid`.
+        // Although it is unlikely, two messages of the same thread may
+        // end up resolving to the same millisecond (hence colliding their
+        // `id` in HTML). The solution is to introduce higher precision
+        // in the hash since it is exceptionally rare that two database
+        // transactions resolve at the exact same nanosecond.
         const creation = await createReply(id, user.user_id, body);
         if (creation instanceof Date) return { mid: creation.getTime() };
 

--- a/src/routes/dashboard/ticket/[id]/+page.svelte
+++ b/src/routes/dashboard/ticket/[id]/+page.svelte
@@ -28,8 +28,8 @@
     <h1 class="h1">{title}</h1>
     <div class="grid grid-cols-[1fr_auto_auto] gap-4">
         <section class="flex flex-col space-y-4">
-            {#each messages as { message_id, body, creation, author_id, name, email, picture } (message_id)}
-                {@const id = message_id.toString()}
+            {#each messages as { creation, body, author_id, name, email, picture } (creation)}
+                {@const id = creation.getTime().toString()}
                 {#if author_id === uid}
                     <article id="{id}" class="grid grid-cols-[1fr_auto] gap-2">
                         <div


### PR DESCRIPTION
This PR sorts the inbox by their priority level (descending with `null` last), then by their due date (ascending), and finally by their creation date (ascending). Note that untriaged tickets are sorted last.

To simplify the queries involved, I removed the `messages.message_id` field in favor of the `messages.creation` field. That is to say, the `creation` field is now the new primary key for the `messages` table. The timestamp (with time zone) should be sufficiently unique for most cases. In the worst (but incredibly exceptional) case when a timestamp collision occurs, the user simply retries the operation.